### PR TITLE
Fix SSL changes.

### DIFF
--- a/source/imap/session.d
+++ b/source/imap/session.d
@@ -164,7 +164,6 @@ struct Session {
     this(ImapServer imapServer, ImapLogin imapLogin, bool useSSL = true, Options options = Options.init) {
         import std.exception : enforce;
         import std.process : environment;
-        import imap.ssl : loadVerifyLocations;
         this.options = options;
         this.server = imapServer.server;
         this.port = imapServer.port;

--- a/source/imap/session.d
+++ b/source/imap/session.d
@@ -169,9 +169,6 @@ struct Session {
         this.server = imapServer.server;
         this.port = imapServer.port;
         this.useSSL = useSSL;
-        if (useSSL) {
-            this.sslContext.loadVerifyLocations(options.trustStore, options.trustFile);
-        }
         this.imapLogin = imapLogin;
     }
 

--- a/source/imap/socket.d
+++ b/source/imap/socket.d
@@ -85,6 +85,7 @@ ref Session openSecureConnection(ref Session session) {
     enforce(session.socket.isAlive, "trying to secure a disconnected socket");
     session.sslContext = getContext("/etc/ssl/cert.pem", "/etc/ssl", null, null, false); // "cacert.pem","/etc/pki/CA",null,null,false);
     enforce(session.sslContext !is null, "unable to create new SSL context");
+    session.sslContext.loadVerifyLocations(session.options.trustStore, session.options.trustFile);
     session.sslConnection = SSL_new(session.sslContext);
     enforce(session.sslConnection !is null, "unable to create new SSL connection");
     enforce(session.socket.isAlive, "trying to secure a disconnected socket");

--- a/source/imap/ssl.d
+++ b/source/imap/ssl.d
@@ -235,23 +235,3 @@ void setDefaultVerifyPaths(SSL_CTX* ctx) {
     auto ret = SSL_CTX_set_default_verify_paths(ctx);
     enforce(ret == 0, "SSL unable to set default verify paths");
 }
-
-void loadVerifyLocations(SSL_CTX* ctx, string caFile, string caPath)
-{
-	import std.exception : enforce;
-	auto ret = SSL_CTX_load_verify_locations(ctx,caFile.toStringz,caPath.toStringz);
-	enforce(ret == 0, "SSL unable to load verify locations");
-}
-
-void setDefaultVerifyPaths(SSL_CTX* ctx)
-{
-	import std.exception : enforce;
-	auto ret = SSL_CTX_set_default_verify_paths(ctx);
-	enforce(ret == 0, "SSL unable to set default verify paths");
-}
-
-
-
-
-
-


### PR DESCRIPTION
- The recent uncrustification left some fragments which broke the build.
- A new call to loadVerifyLocations() was made in the Session ctor
  before the SSL context is initialised.  This has been moved to
  openSecureConnection() after the context is created.

NOTE: Cert verification still isn't done by default as Session.noCerts
defaults to true and is not changed.