### PR TITLE
Bugfix response parsing

### DIFF
--- a/source/imap/socket.d
+++ b/source/imap/socket.d
@@ -167,7 +167,7 @@ private string sslConnectionSysCallError(int socketStatus) {
 /// Disconnect from mail server.
 void closeConnection(ref Session session) {
     version (SSL) closeSecureConnection(session);
-    if (session.socket.isAlive) {
+    if (session.socket !is null && session.socket.isAlive) {
         session.socket.close();
     }
 }


### PR DESCRIPTION
Improve some response parsing.

- `STATUS` response parsing was just simplified.
- `LIST` response parsing was made a little more robust, to support more than one attribute per mailbox.

This is still far from ideal -- we need a proper parser (e.g., `grammar.d`) to parse these responses and for some decent tests to confirm them.  This is on my todo list.

A little fix for `socket.d` is also there.