### PR TITLE
Allow the FETCH methods to take either a seq ID or a UID.

### DIFF
--- a/source/imap/request.d
+++ b/source/imap/request.d
@@ -475,92 +475,81 @@ auto multiSearch(ref Session session, string criteria, SearchResultType[] result
     return r;
 }
 
+int sendFetchRequest(ref Session session, string id, string itemSpec) {
+    import std.format : format;
+
+    // Does the id start with '#'?
+    if (id.length > 1 && id[0] == '#') {
+        // A mailbox sequence id which should be in the range 1 to mailbox-message-count.
+        return session.sendRequest(format!"FETCH %s %s"(id[1 .. $], itemSpec));
+    }
+
+    // Otherwise it's a mailbox uid.
+    return session.sendRequest(format!"UID FETCH %s %s"(id, itemSpec));
+}
+
 @SILdoc("Fetch the FLAGS, INTERNALDATE and RFC822.SIZE of the messages")
 auto fetchFast(ref Session session, string mesg) {
-    import std.format : format;
-    auto t = session.imapTry!sendRequest(format!"UID FETCH %s FAST"(mesg));
-    auto r = session.responseFetchFast(t);
-    return r;
+    auto t = session.imapTry!sendFetchRequest(mesg, "FAST");
+    return session.responseFetchFast(t);
 }
 
 @SILdoc("Fetch the FLAGS of the messages")
 auto fetchFlags(ref Session session, string mesg) {
-    import std.format : format;
-    auto t = session.imapTry!sendRequest(format!"UID FETCH %s FLAGS"(mesg));
+    auto t = session.imapTry!sendFetchRequest(mesg, "FLAGS");
     return session.responseFetchFlags(t);
 }
 
 @SILdoc("Fetch the INTERNALDATE of the messages")
 auto fetchDate(ref Session session, string mesg) {
-    import std.format : format;
-    auto request = format!"UID FETCH %s INTERNALDATE"(mesg);
-    auto id = session.imapTry!sendRequest(request);
+    auto id = session.imapTry!sendFetchRequest(mesg, "INTERNALDATE");
     return session.responseFetchDate(id);
 }
 
 @SILdoc("Fetch the RFC822.SIZE of the messages")
 auto fetchSize(ref Session session, string mesg) {
-    import std.format : format;
-    auto request = format!"UID FETCH %s RFC822.SIZE"(mesg);
-    auto id = session.imapTry!sendRequest(request);
+    auto id = session.imapTry!sendFetchRequest(mesg, "RFC822.SIZE");
     return session.responseFetchSize(id);
 }
 
 @SILdoc("Fetch the BODYSTRUCTURE of the messages")
 auto fetchStructure(ref Session session, string mesg) {
-    import std.format : format;
-    auto request = format!"UID FETCH %s BODYSTRUCTURE"(mesg);
-    auto id = session.imapTry!sendRequest(request);
+    auto id = session.imapTry!sendFetchRequest(mesg, "BODYSTRUCTURE");
     return session.responseFetchStructure(id);
 }
 
-
 @SILdoc("Fetch the BODY[HEADER] of the messages")
 auto fetchHeader(ref Session session, string mesg) {
-    import std.format : format;
-
-    auto id  = session.imapTry!sendRequest(format!`UID FETCH %s BODY.PEEK[HEADER]`(mesg));
-    auto r = session.responseFetchBody(id);
-    return r;
+    auto id  = session.imapTry!sendFetchRequest(mesg, "BODY.PEEK[HEADER]");
+    return session.responseFetchBody(id);
 }
 
-
-@SILdoc("Fetch the text, ie. BODY[TEXT], of the messages")
+@SILdoc("Fetch the entire message text, ie. RFC822, of the messages")
 auto fetchRFC822(ref Session session, string mesg) {
-    import std.format : format;
-
-    auto id  = session.imapTry!sendRequest(format!`UID FETCH %s RFC822`(mesg));
-    auto r = session.responseFetchBody(id);
-    return r;
+    auto id  = session.imapTry!sendFetchRequest(mesg, "RFC822");
+    return session.responseFetchBody(id);
 }
 
 @SILdoc("Fetch the text, ie. BODY[TEXT], of the messages")
 auto fetchText(ref Session session, string mesg) {
-    import std.format : format;
-
-    auto id  = session.imapTry!sendRequest(format!`UID FETCH %s BODY.PEEK[TEXT]`(mesg));
-    auto r = session.responseFetchBody(id);
-    return r;
+    auto id  = session.imapTry!sendFetchRequest(mesg, "BODY.PEEK[TEXT]");
+    return session.responseFetchBody(id);
 }
-
 
 @SILdoc("Fetch the specified header fields, ie. BODY[HEADER.FIELDS (<fields>)], of the messages.")
 auto fetchFields(ref Session session, string mesg, string headerFields) {
     import std.format : format;
-
-    auto id  = session.imapTry!sendRequest(format!`UID FETCH %s BODY.PEEK[HEADER.FIELDS (%s)]`(mesg, headerFields));
-    auto r = session.responseFetchBody(id);
-    return r;
+    auto itemSpec = format!`BODY.PEEK[HEADER.FIELDS (%s)]`(headerFields);
+    auto id  = session.imapTry!sendFetchRequest(mesg, itemSpec);
+    return session.responseFetchBody(id);
 }
-
 
 @SILdoc("Fetch the specified message part, ie. BODY[<part>], of the messages")
 auto fetchPart(ref Session session, string mesg, string part) {
     import std.format : format;
-
-    auto id  = session.imapTry!sendRequest(format!`UID FETCH %s BODY.PEEK[%s]`(mesg, part));
-    auto r = session.responseFetchBody(id);
-    return r;
+    auto itemSpec = format!`BODY.PEEK[%s]`(part);
+    auto id  = session.imapTry!sendFetchRequest(mesg, itemSpec);
+    return session.responseFetchBody(id);
 }
 
 enum StoreMode {


### PR DESCRIPTION
OK, here's the controversial one.

This change has each of the `FETCH` methods using a utility to interpret the ID.  If the id is prefixed with a '#' it is now treated as a mailbox sequence ID (i.e., 1 to len(messages)), otherwise it's treated as a UID as before.

See [issue #39](https://github.com/symmetryinvestments/imap-d/issues/39)