### PR TITLE
Add some example SIL scripts.

### DIFF
--- a/SIL/examples/README.md
+++ b/SIL/examples/README.md
@@ -1,0 +1,137 @@
+# SIL Examples
+
+This directory contains some examples of how to use the **imap-d** SIL plugin.
+
+## Biff
+
+`biff.sil` implements a simple [Biff-like](https://en.wikipedia.org/wiki/Biff_(Unix)) utility.
+
+```console
+$ IMAP_USER=alice IMAP_PASS='secret' sil biff.sil -- --host=imap.example.com --port=993
+   _____   ______   __
+ //  ___\ ||_   _| || |
+ \\ `--.    || |   || |
+   `--. \   || |   || |
+ //___/ /  _|| |_  || |___
+ \\____/  ||_____| ||_____|
+Symmetry Integration Language
+Version: 2.4.0
+
+- loading biff.sil
+INBOX: 5 new, 6 total.
+```
+
+## List Mailboxes
+
+`list_mailboxes.sil` shows the hierarchy of all the IMAP mailboxes.  Mailboxes
+with sub-folders are marked with a '+'.
+
+```console
+$ IMAP_USER=alice IMAP_PASS='secret' sil list_mailboxes.sil -- --host=imap.example.com --port=993
+   _____   ______   __
+ //  ___\ ||_   _| || |
+ \\ `--.    || |   || |
+   `--. \   || |   || |
+ //___/ /  _|| |_  || |___
+ \\____/  ||_____| ||_____|
+Symmetry Integration Language
+Version: 2.4.0
+
+- loading list_mailboxes.sil
+Mailboxes:
+  + archive
+    archive.work
+    archive.personal
+    spam
+    INBOX
+```
+## Headers
+
+`headers.sil` provides a quick summary of the mail in a mailbox.  It prints the date, from and
+subject fields in the order they appear in the mailbox.
+
+```console
+$ IMAP_USER=alice IMAP_PASS='secret' sil headers.sil -- --host=imap.example.com --port=993
+   _____   ______   __
+ //  ___\ ||_   _| || |
+ \\ `--.    || |   || |
+   `--. \   || |   || |
+ //___/ /  _|| |_  || |___
+ \\____/  ||_____| ||_____|
+Symmetry Integration Language
+Version: 2.4.0
+
+- loading headers.sil
+INBOX:
+  Wed, 19 Jul 2017 14:28:21 +1000 (AEST)   | carlos <carlos@example.com>              | older email
+  Tue, 24 Dec 2019 20:51:04 +1100 (AEDT)   | bob <bob@example.com>                    | test 1
+  Fri, 31 Jan 2020 13:41:41 +1100 (AEDT)   | bob <bob@example.com>                    | recent email
+```
+
+## Search
+
+`search.sil` searches for messages matching a pattern with optional formatted reporting.
+
+An example support mailbox:
+```
+"support.mbox": 17 messages 17 new
+ N  1 robot@example.com     Mon May 11 22:26  28/1369  "Alert: new issue 123"
+ N  2 robot@example.com     Tue May 12 12:20  22/933   "Notification: service change"
+ N  3 robot@example.com     Tue May 12 12:36  26/1341  "Alert: new issue 124"
+ N  4 robot@example.com     Wed May 13 02:13  21/921   "Resolution: issue 124"
+ N  5 person@example.com    Wed May 13 18:53  26/1332  "Email not from robot."
+ N  6 robot@example.com     Thu May 14 03:13  27/1339  "Alert: new issue 125"
+ N  7 robot@example.com     Thu May 14 08:46  26/1270  "Resolution: issue 123"
+ N  8 robot@example.com     Thu May 14 17:06  25/1249  "Alert: new issue 126"
+ N  9 robot@example.com     Fri May 15 09:46  24/1185  "Resolution: issue 126"
+ N 10 robot@example.com     Fri May 15 12:33  23/1052  "Alert: new issue 127"
+ N 11 robot@example.com     Fri May 15 15:20  27/1331  "Notification: service change"
+ N 12 robot@example.com     Fri May 15 18:06  23/953   "Resolution: issue 127"
+ N 13 robot@example.com     Mon May 18 12:46  27/1218  "Alert: new issue 128"
+ N 14 robot@example.com     Mon May 18 15:33  32/1628  "Alert: new issue 129"
+ N 15 robot@example.com     Tue May 19 05:26  25/1176  "Resolution: issue 128"
+ N 16 robot@example.com     Tue May 19 08:13  26/1312  "Notification: service change"
+ N 17 robot@example.com     Tue May 19 11:00  28/1275  "Alert: new issue 130"
+```
+Each of these automated emails are from `robot` _except_ for message 5.  Messages 2, 8 and 16 are
+from `robot` but are unrelated to issues.
+
+The script performs a search using the format specified in the [IMAP RFC](https://tools.ietf.org/html/rfc3501#section-6.4.4).
+
+> E.g.,
+> SEARCH FROM robot@example.com SUBJECT "Alert: new issue" SENTSINCE 13-may-2020
+
+It will correlate the resolutions IDs with alert IDs and print a report showing the outstanding
+issues.
+
+```console
+$ IMAP_USER=alice IMAP_PASS='secret' sil search.sil -- --host=imap.example.com --port=993
+   _____   ______   __
+ //  ___\ ||_   _| || |
+ \\ `--.    || |   || |
+   `--. \   || |   || |
+ //___/ /  _|| |_  || |___
+ \\____/  ||_____| ||_____|
+Symmetry Integration Language
+Version: 2.4.0
+
+- loading search.sil
+
+UNRESOLVED ISSUES FROM THE PAST 10 DAYS:
+
+Issue: 125
+  Date: Thu, 14 May 2020 03:13:20 +1000 (AEST)
+  Summary: Process 123 'perl' crashed.
+Issue: 129
+  Date: Mon, 18 May 2020 15:33:20 +1000 (AEST)
+  Summary: Unexpected reboot.
+Issue: 130
+  Date: Tue, 19 May 2020 11:00:00 +1000 (AEST)
+  Summary: Snack box is empty.
+```
+
+For the example emails above it found that issues 125, 129 and 130 were unresolved and printed the
+date they were reported and the first line from the message body for a summary.
+
+This is a fairly contrived example but it shows how searching for specific criteria can be used to
+generate a useful automated report.

--- a/SIL/examples/biff.sil
+++ b/SIL/examples/biff.sil
@@ -1,0 +1,22 @@
+import imap
+import imap_config
+
+// Get the configuration from the environment and command line.
+config = imap_config.getConfig(commandLineArguments)
+
+// Connect to the inbox.
+creds = imap.ImapLogin(config.user, config.pass)
+server = imap.ImapServer(config.host, config.port)
+session =
+  imap.Session(server, creds)
+  |> imap.openConnection().returnValue
+  |> imap.login().returnValue
+
+// Get the status for the inbox.
+stat = (imap.Mailbox("INBOX", "", '/') |> imap.status(session, _)).returnValue
+
+// Close the session.
+imap.closeConnection(session)
+
+// Count new messages and all messages.
+print("INBOX: " ~ toString(stat.unseen) ~ " new, " ~ toString(stat.messages) ~ " total.")

--- a/SIL/examples/headers.sil
+++ b/SIL/examples/headers.sil
@@ -1,0 +1,67 @@
+import imap
+import imap_config
+import string
+
+// Get the configuration from the environment and command line.
+config = imap_config.getConfig(commandLineArguments)
+
+// -------------------------------------------------------------------------------------------------
+// Some helper functions.
+//
+// Firstly, a field formatter which strips the field prefix and pads to a fixed width.
+// E.g., ("From: me@here.com" |> fmtField(20)) == "me@here.com         "
+
+fmtField(field, width) => {
+// Use the following when we know how to concat arrayOf char and string.
+//  field
+//    |> findSplitAfter(": ").after
+//    |> padRight(' ', width)
+//    |> array
+
+  // Using this in the meantime.
+  pad(str) => iota(width - len(str)) |> fold((a, i) => a ~ " ", str)
+  in field
+    |> string.split(": ")[1:$]
+    |> fold((a, s) => a ~ s, "")
+    |> pad
+}
+
+// Secondly, a function to join an array of strings.
+
+joinFields(flds, sep) => {
+  fold(flds[1:$], (str, fld) => str ~ sep ~ fld, flds[0])
+}
+
+// And thirdly, a function which concatenates the headers into a formatted string.
+
+fmtHeaders(outStr, headers) => {
+  outStr ~ "  " ~ joinFields(headers, " | ") ~ "\n"
+}
+
+// -------------------------------------------------------------------------------------------------
+
+// Connect to the inbox.
+creds = imap.ImapLogin(config.user, config.pass)
+server = imap.ImapServer(config.host, config.port)
+session =
+  imap.Session(server, creds)
+  |> imap.openConnection().returnValue
+  |> imap.login().returnValue
+inbox = imap.Mailbox("INBOX", "", '/')
+
+// Get the number of messages in the inbox.
+msgCount = imap.status(session, inbox).returnValue.messages
+
+// Select the default inbox.
+inbox |> imap.examine(session, _)
+
+// Get the headers (date, from and subject) for each message, from oldest to newest, format and
+// print them.
+headers =
+  iota(msgCount)
+    |> map(id => "#" ~ toString(id + 1))
+    |> map(id =>
+         imap.fetchFields(session, id, "date from subject").returnValue.lines
+           |> map(hdr => fmtField(hdr, 40)))
+    |> fold(fmtHeaders, "INBOX:\n")
+print(headers)

--- a/SIL/examples/imap_config.sil
+++ b/SIL/examples/imap_config.sil
@@ -1,0 +1,27 @@
+import getopt
+
+// A utility to get the username, password, hostname and port for each of the example scripts.
+
+getConfig(args) => {
+  // Get the hostname:port, username:passwd.  First, check the environment.
+  config = {
+    "user" : environment("IMAP_USER"),
+    "pass" : environment("IMAP_PASS"),
+    "host" : "",
+    "port" : ""
+  }
+
+  // Then get them from the command line, which overrides the environment.
+  cmdLineOpts = getopt.getopt(args, ["user", "pass", "host", "port"])
+  config =
+    keys(cmdLineOpts)
+    |> fold((cfg, key) => cfg |> replaceEntry(key, cmdLineOpts[key]), config)
+
+  // Make sure we have all of the configuration.
+  enforce(len(config.user) != 0, "Must supply username via IMAP_USER env var or --user option.")
+  enforce(len(config.pass) != 0, "Must supply password via IMAP_PASS env var or --pass option.")
+  enforce(len(config.host) != 0 && len(config.port) != 0,
+    "Must supply host and port via --host and --port options.")
+
+  in config
+}

--- a/SIL/examples/list_mailboxes.sil
+++ b/SIL/examples/list_mailboxes.sil
@@ -1,0 +1,27 @@
+import imap
+import imap_config
+
+config = imap_config.getConfig(commandLineArguments)
+
+// Connect to the inbox.
+creds = imap.ImapLogin(config.user, config.pass)
+server = imap.ImapServer(config.host, config.port)
+session =
+  imap.Session(server, creds)
+  |> imap.openConnection().returnValue
+  |> imap.login().returnValue
+
+// Get a list of all the mailboxes.
+list = imap.list(session).returnValue
+
+// Close the session.
+imap.closeConnection(session)
+
+// Print the mailboxes, each on a line marking those with children with a '+'.
+list.entries
+  |> fold((str, entry) => {
+       flag = if canFind(entry.attributes, 4) then "  + " else "    "
+       in str ~ flag ~ entry.path ~ "\n"
+     },
+     "Mailboxes:\n")
+  |> print

--- a/SIL/examples/search.sil
+++ b/SIL/examples/search.sil
@@ -1,0 +1,104 @@
+// This script will create a report based on a specific example set of automated 'support' emails.
+// E.g.,
+//
+// "support.mbox": 17 messages 17 new
+//  N  1 robot@example.com     Mon May 11 22:26  28/1369  "Alert: new issue 123"
+//  N  2 robot@example.com     Tue May 12 12:20  22/933   "Notification: service change"
+//  N  3 robot@example.com     Tue May 12 12:36  26/1341  "Alert: new issue 124"
+//  N  4 robot@example.com     Wed May 13 02:13  21/921   "Resolution: issue 124"
+//  N  5 person@example.com    Wed May 13 18:53  26/1332  "Email not from robot."
+//  N  6 robot@example.com     Thu May 14 03:13  27/1339  "Alert: new issue 125"
+//  N  7 robot@example.com     Thu May 14 08:46  26/1270  "Resolution: issue 123"
+//  N  8 robot@example.com     Thu May 14 17:06  25/1249  "Alert: new issue 126"
+//  N  9 robot@example.com     Fri May 15 09:46  24/1185  "Resolution: issue 126"
+//  N 10 robot@example.com     Fri May 15 12:33  23/1052  "Alert: new issue 127"
+//  N 11 robot@example.com     Fri May 15 15:20  27/1331  "Notification: service change"
+//  N 12 robot@example.com     Fri May 15 18:06  23/953   "Resolution: issue 127"
+//  N 13 robot@example.com     Mon May 18 12:46  27/1218  "Alert: new issue 128"
+//  N 14 robot@example.com     Mon May 18 15:33  32/1628  "Alert: new issue 129"
+//  N 15 robot@example.com     Tue May 19 05:26  25/1176  "Resolution: issue 128"
+//  N 16 robot@example.com     Tue May 19 08:13  26/1312  "Notification: service change"
+//  N 17 robot@example.com     Tue May 19 11:00  28/1275  "Alert: new issue 130"
+//
+//
+// Each of these automated emails are from `robot` _except_ for message 5.  Messages 2, 8 and 16 are
+// from `robot` but are unrelated to issues.
+//
+// This script will search for emails and match new issue numbers with resolutions to report the
+// number of outstanding alerts.
+
+import imap
+import imap_config
+import string
+
+// Get the configuration from the environment and command line.
+config = imap_config.getConfig(commandLineArguments)
+
+// Connect to the inbox.
+creds = imap.ImapLogin(config.user, config.pass)
+server = imap.ImapServer(config.host, config.port)
+session =
+  imap.Session(server, creds)
+    |> imap.openConnection().returnValue
+    |> imap.login().returnValue
+inbox = imap.Mailbox("INBOX", "", '/')
+
+// Select the default inbox.
+inbox |> imap.examine(session, _)
+
+// Specify some search criteria to be combined for different searches.
+fromCrit   = "FROM robot@example.com"
+alertCrit  = "SUBJECT \"Alert: new issue\""
+resCrit    = "SUBJECT \"Resolution: issue\""
+afterCrit  = "SENTSINCE 13-may-2020"
+
+// Function to join search criteria.
+joinQuery(crita) => fold(crita[1:$], (str, crit) => str ~ " " ~ crit, crita[0])
+
+// Get each of the alerts and resolutions from the past week (13-19 May).
+alertMsgIds =
+  imap.search(session, joinQuery([fromCrit, afterCrit, alertCrit])).returnValue.ids
+resolutionMsgIds =
+  imap.search(session, joinQuery([fromCrit, afterCrit, resCrit])).returnValue.ids
+
+// A function to get the alert ID from a message subject.
+getAlertId(msgId) => {
+  imap.fetchFields(session, toString(msgId), "subject").returnValue.lines[0]
+    |> string.split()[$ - 1]
+}
+
+// A function to remove an entry from a table whether it's there or not.
+removeIfExists(tbl, key) => {
+  if find(keys(tbl), key) == [] then
+    tbl
+  else
+    removeEntry(tbl, key)
+}
+
+// Now find those alerts which have no resolution.  Firstly the subject for each alert, get the
+// issue number end and store it in a table.
+allAlertTable = alertMsgIds |> fold((tbl, msgId) => addEntry(tbl, getAlertId(msgId), msgId), {})
+
+// Go through the resolutions and remove their corresponding alerts from the table.
+unresolvedAlertTable =
+  resolutionMsgIds |> fold((tbl, msgId) => removeIfExists(tbl, getAlertId(msgId)), allAlertTable)
+
+// Create a report with the date of the unresolved alerts.
+report =
+  keys(unresolvedAlertTable)
+    |> map(alertId => {
+         msgId = unresolvedAlertTable[alertId] |> toString
+       in [ alertId,
+            imap.fetchFields(session, msgId, "date").returnValue.lines[0],
+            imap.fetchText(session, msgId).returnValue.lines[1]
+          ]
+       })
+    |> fold((outStr, tuple) => {
+         outStr ~ "Issue: " ~ tuple[0] ~ "\n  " ~ tuple[1] ~ "\n  Summary: " ~ tuple[2] ~ "\n"
+       }, "\nUNRESOLVED ISSUES FROM THE PAST 10 DAYS:\n\n")
+
+// Close the session.
+imap.closeConnection(session)
+
+// Print the report last.
+print(report)


### PR DESCRIPTION
Some example SIL scripts.  Most of them won't work until the other PRs are merged.

- `biff.sil` reports the number of unread messages in the INBOX.
- `list_mailboxes.sil` shows all the mailboxes in an account.
- `headers.sil` shows a summary of all the emails in the INBOX.
- `search.sil` produces a report based on reconciling support issues.