### PR TITLE
Streamline the travis-ci config.

### DIFF
--- a/.travis-install-openssl.sh
+++ b/.travis-install-openssl.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 
 set -euxo pipefail
-git clone https://github.com/openssl/openssl
-pushd openssl
+
+# Install dependency packages.
+apt install -y libssl-dev
+
+# Fetch the version 1.1.1g of the OpenSSL source.
+wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1g.tar.gz
+tar xzf OpenSSL_1_1_1g.tar.gz
+
+# Build and install it under /usr/local/openssl.
+pushd openssl-OpenSSL_1_1_1g
 ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl shared zlib
 make
-sudo make install
+make install
 popd
+
+# Create a package config file which points to our new installation.
 cat > libssl.pc << EOF
 prefix=/usr/local/openssl
 exec_prefix=\${prefix}
@@ -21,5 +31,7 @@ Requires.private: libcrypto
 Libs: -L\${libdir} -L\${sharedlibdir} -lssl
 Cflags: -I\${includedir}
 EOF
-sudo mv libssl.pc /usr/lib/x86_64-linux-gnu/pkgconfig/libssl.pc
+
+# Install it manually.
+mv libssl.pc /usr/lib/x86_64-linux-gnu/pkgconfig/libssl.pc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,13 @@
 language: d
-sudo: false
 dist: bionic
 
-before_install:
-  - sudo apt update
-  - sudo apt install -y libssl-dev build-essential checkinstall zlib1g-dev
-  - sudo ./travis_install_deps.sh
-  
-install:
-  - mkdir bin
+d:
+  - dmd
+  - ldc
 
-matrix:
-  include:
-    - d: dmd-nightly
-    - d: dmd-2.089.0
-    - d: dmd-2.088.1
-    - d: dmd-2.087.1
-    - d: ldc-1.18.0
-    - d: ldc-1.17.0
-    - d: ldc-1.16.0
-  allow_failures:
-    - d: dmd-nightly
+before_install:
+  - sudo ./.travis-install-openssl.sh
 
 script:
-  - ./travis.sh
-
-after_success:
- - bash <(curl -s https://codecov.io/bash)
+  - dub build --compiler=${DC}
+  - dub build --compiler=${DC} --root=example

--- a/travis.sh
+++ b/travis.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euxo pipefail
-dub build --vverbose
-pushd example
-dub build --compiler=${DC} --vverbose
-popd
-# && dub test --build=unittest-cov --compiler=${DC}


### PR DESCRIPTION
It's now passing again.

- Switched to just the latest versions of dmd and ldc.
- Still only building, no tests as they're currently broken.
- Still building OpenSSL as a dependency, though this could still be
  streamlined further (don't need to install all the docs, etc.).
- Removed travis.sh and moved travis_install_deps.sh to
  .travis-install-openssl.sh.
- Don't call the codecov.io script since our tests aren't running.