### PR TITLE
Small bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ example/imap-example
 tags
 
 # SIL REPL artefacts.
+replrc
 SIL.log
 SIL_user.log
 history.txt

--- a/source/imap/namespace.d
+++ b/source/imap/namespace.d
@@ -335,7 +335,7 @@ struct Mailbox {
         if ((prefix.length == 0) && ((delim == '\0') || delim == '/'))
             return mbox;
         auto ret = format!"%s%s"(prefix, mbox).replace("/", [delim]);
-        infof("namespace: '%s' -> '%s'\n", mbox, ret);
+        version(Trace) infof("namespace: '%s' -> '%s'\n", mbox, ret);
         return ret;
     }
     //// Convert the names of personal mailboxes, using the namespace specified by

--- a/source/imap/request.d
+++ b/source/imap/request.d
@@ -380,9 +380,9 @@ auto list(ref Session session, string referenceName = "", string mailboxName = "
 
 
 @SILdoc("List subscribed mailboxes")
-auto lsub(ref Session session, string refer, string name) {
+auto lsub(ref Session session, string refer = "", string name = "*") {
     import std.format : format;
-    auto request = format!`LIST "%s" "%s"`(refer, name);
+    auto request = format!`LSUB "%s" "%s"`(refer, name);
     auto id = session.imapTry!sendRequest(request);
     return session.responseList(id);
 }
@@ -732,7 +732,7 @@ auto subscribe(ref Session session, Mailbox mailbox) {
 @SILdoc("Unsubscribe from the specified mailbox.")
 auto unsubscribe(ref Session session, Mailbox mailbox) {
     import std.format : format;
-    auto request = format!`UNSUBSCRIBE"%s"`(mailbox.toString);
+    auto request = format!`UNSUBSCRIBE "%s"`(mailbox.toString);
     auto id = session.sendRequest(request);
     return session.responseGeneric(id);
 }

--- a/source/imap/request.d
+++ b/source/imap/request.d
@@ -249,14 +249,6 @@ int logout(ref Session session) {
     return ImapStatus.ok;
 }
 
-@SILdoc("Mailbox status returned by IMAP status command")
-struct MailboxImapStatus {
-    uint exists;
-    uint recent;
-    uint unseen;
-    uint uidnext;
-}
-
 @SILdoc("IMAP examine command for mailbox mbox")
 auto examine(ref Session session, Mailbox mbox) {
     import std.format : format;
@@ -290,23 +282,11 @@ auto select(ref Session session, Mailbox mailbox) {
 
 
 @SILdoc("Close examined/selected mailbox")
-ImapResult raw(ref Session session, string command) {
-    auto id = sendRequest(session, command);
-    auto response = responseGeneric(session, id);
-    if (response.status == ImapStatus.ok && session.socket.isAlive) {
-        session.close();
-        session.selected = Mailbox.init;
-    }
-    return response;
-}
-
-@SILdoc("Close examined/selected mailbox")
 ImapResult close(ref Session session) {
     enum request = "CLOSE";
     auto id = sendRequest(session, request);
     auto response = responseGeneric(session, id);
-    if (response.status == ImapStatus.ok && session.socket.isAlive) {
-        session.close();
+    if (response.status == ImapStatus.ok) {
         session.selected = Mailbox.init;
     }
     return response;

--- a/source/imap/request.d
+++ b/source/imap/request.d
@@ -154,7 +154,7 @@ ref Session login(ref Session session) {
     scope (failure)
         closeConnection(session);
     if (session.socket is null || !session.socket.isAlive()) {
-        infof("login called with dead socket, so trying to reconnect");
+        if (session.options.debugMode) infof("login called with dead socket, so trying to reconnect");
         session = openConnection(session);
         if (session.useSSL && !session.options.startTLS)
             session = openSecureConnection(session);
@@ -217,7 +217,7 @@ ref Session login(ref Session session) {
         }
         if (rl == ImapStatus.no) {
             auto err = format!"username %s or password rejected at %s\n"(login.username, session.server);
-            errorf("username %s or password rejected at %s\n", login.username, session.server);
+            if (session.options.debugMode) errorf("username %s or password rejected at %s\n", login.username, session.server);
             session.closeConnection();
             throw new Exception(err);
         }

--- a/source/imap/request.d
+++ b/source/imap/request.d
@@ -156,8 +156,6 @@ ref Session login(ref Session session) {
     if (session.socket is null || !session.socket.isAlive()) {
         if (session.options.debugMode) infof("login called with dead socket, so trying to reconnect");
         session = openConnection(session);
-        if (session.useSSL && !session.options.startTLS)
-            session = openSecureConnection(session);
     }
     enforce(session.socket.isAlive(), "not connected to server");
 

--- a/source/imap/response.d
+++ b/source/imap/response.d
@@ -102,10 +102,10 @@ ImapStatus checkTag(ref Session session, string buf, Tag tag) {
     if (session.options.debugMode) tracef("tag result is status %s for lines: %s", r, relevantLines);
 
     if (r != ImapStatus.none && session.options.debugMode)
-        tracef("S (%s): %s / %s", session.socket, buf, relevantLines);
+        if (session.options.debugMode) tracef("S (%s): %s / %s", session.socket, buf, relevantLines);
 
     if (r == ImapStatus.no || r == ImapStatus.bad)
-        errorf("IMAP (%s): %s / %s", session.socket, buf, relevantLines);
+        if (session.options.debugMode) errorf("IMAP (%s): %s / %s", session.socket, buf, relevantLines);
 
     return r;
 }

--- a/source/imap/response.d
+++ b/source/imap/response.d
@@ -203,7 +203,8 @@ ImapResult responseContinuation(ref Session session, Tag tag) {
         if (checkBye(result[1]))
             return ImapResult(ImapStatus.bye, result[1]);
         resTag = session.checkTag(result[1], tag);
-    } while ((resTag != ImapStatus.none) && !result[1].strip.splitLines.any!(line => line.strip.checkContinuation));
+    } while (resTag != ImapStatus.none && resTag != ImapStatus.no &&
+             !result[1].strip.splitLines.any!(line => line.strip.checkContinuation));
 
     if (resTag == ImapStatus.no && (checkTryCreate(buf) || session.options.tryCreate))
         return ImapResult(ImapStatus.tryCreate, buf);

--- a/source/imap/session.d
+++ b/source/imap/session.d
@@ -86,8 +86,8 @@ struct ImapLogin {
 struct Options {
     import core.time : Duration, seconds, minutes;
 
-    bool debugMode = true;
-    bool verboseOutput = true;
+    bool debugMode = false;
+    bool verboseOutput = false;
     bool interactive = false;
     bool namespace = false;
 

--- a/source/imap/socket.d
+++ b/source/imap/socket.d
@@ -243,7 +243,7 @@ Result!string socketRead(ref Session session, Duration timeout, bool timeoutFail
 
     enforce(s != -1, format!"waiting to read from socket; %s"(strerror(errno).fromStringz));
     enforce(s != 0 || !timeoutFail, "timeout period expired while waiting to read data");
-    tracef("socketRead: %s / %s", session.socket, buf);
+    version (Trace) tracef("socketRead: %s / %s", session.socket, buf);
     return result(Status.success, cast(string) buf[0 .. r]);
 }
 
@@ -355,9 +355,9 @@ ssize_t socketWrite(ref Session session, string buf) {
     r = t = 0;
     s = 1;
 
-    tracef("socketWrite: %s / %s", session.socket, buf);
+    version (Trace) tracef("socketWrite: %s / %s", session.socket, buf);
     if (session.sslConnection) {
-        tracef("socketSecureWrite: %s / %s", session.socket, buf);
+        version (Trace) tracef("socketSecureWrite: %s / %s", session.socket, buf);
         return session.socketSecureWrite(buf);
     }
 
@@ -367,12 +367,12 @@ ssize_t socketWrite(ref Session session, string buf) {
     auto socketSet = new SocketSet(1);
     socketSet.add(session.socket);
 
-    tracef("entering loop with buf.length=%s", buf.length);
+    version (Trace) tracef("entering loop with buf.length=%s", buf.length);
     while (buf.length > 0) {
-        tracef("buf is of length %s", buf.length);
-        tracef("sending buf: %s", buf);
+        version (Trace) tracef("buf is of length %s", buf.length);
+        version (Trace) tracef("sending buf: %s", buf);
         r = session.socket.send(cast(void[]) buf);
-        tracef("r=: %s", r);
+        version (Trace) tracef("r=: %s", r);
         enforce(r != -1, format!"writing data; %s"(strerror(errno).fromStringz));
         enforce(r != 0, "unknown error");
 
@@ -380,7 +380,7 @@ ssize_t socketWrite(ref Session session, string buf) {
             enforce(r <= buf.length, "send to socket returned more bytes than we sent!");
             buf = buf[r .. $];
             t += r;
-            tracef("buf now =: %s", buf);
+            version (Trace) tracef("buf now =: %s", buf);
         }
     }
 
@@ -400,7 +400,7 @@ auto socketSecureWrite(ref Session session, string buf) {
     int r;
     size_t e;
 
-    tracef("socketSecureWrite: %s / %s", session.socket, buf);
+    version (Trace) tracef("socketSecureWrite: %s / %s", session.socket, buf);
     enforce(session.sslConnection, "no SSL connection has been established");
     if (buf.length == 0)
         return 0;

--- a/source/kaleidic/sil/plugin/imap/register.d
+++ b/source/kaleidic/sil/plugin/imap/register.d
@@ -126,9 +126,9 @@ void registerImap(ref Handlers handlers) {
         scope (exit) handlers.closeModule();
         handlers.registerGrammar();
 
-        static foreach (T; AliasSeq!(MailboxImapStatus, MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
+        static foreach (T; AliasSeq!(MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
                                      Status, FlagResult, SearchResult, Status, Session, ProtocolSSL, ImapServer, ImapLogin,
-                                     MailboxImapStatus, MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
+                                     MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
                                      Status, FlagResult, SearchResult, Status, StatusResult, BodyResponse, ListResponse, ListEntry,
                                      IncomingEmailMessage, RelayInfo, ToType, EmailMessage, MimePart, Options,
                                      MimeContainer_, MimePart,
@@ -148,7 +148,7 @@ void registerImap(ref Handlers handlers) {
         static foreach (F; AliasSeq!(noop, login, logout, status, examine, select, close, expunge, list, lsub,
                                      search, fetchFast, fetchFlags, fetchDate, fetchSize, fetchStructure, fetchHeader,
                                      fetchText, fetchFields, fetchPart, logout, store, copy, create, delete_, rename, subscribe,
-                                     unsubscribe, idle, openConnection, closeConnection, raw, fetchRFC822, attachments, writeBinaryString,
+                                     unsubscribe, idle, openConnection, closeConnection, fetchRFC822, attachments, writeBinaryString,
                                      createQuery, searchQuery, searchQueries, rfcDate, esearch, multiSearch, move, multiMove, moveUIDs,
                                      extractAddress,
                         ))


### PR DESCRIPTION
These are some small fixes I've found while writing tests.  Most are fixes for typos or copy-n-paste errors, or removing unused code.

Two of the larger changes are to default to no tracing or debug output to the console by default, and the partial implementation of `append()` which was necessary to get the tests useful.