### PR TITLE
Make session a class

### DIFF
--- a/SIL/examples/biff.sil
+++ b/SIL/examples/biff.sil
@@ -9,11 +9,11 @@ creds = imap.ImapLogin(config.user, config.pass)
 server = imap.ImapServer(config.host, config.port)
 session =
   imap.Session(server, creds)
-  |> imap.openConnection().returnValue
-  |> imap.login().returnValue
+  |> imap.openConnection()
+  |> imap.login()
 
 // Get the status for the inbox.
-stat = (imap.Mailbox("INBOX", "", '/') |> imap.status(session, _)).returnValue
+stat = (imap.Mailbox("INBOX", "", '/') |> imap.status(session, _))
 
 // Close the session.
 imap.closeConnection(session)

--- a/SIL/examples/headers.sil
+++ b/SIL/examples/headers.sil
@@ -39,12 +39,12 @@ creds = imap.ImapLogin(config.user, config.pass)
 server = imap.ImapServer(config.host, config.port)
 session =
   imap.Session(server, creds)
-  |> imap.openConnection().returnValue
-  |> imap.login().returnValue
+  |> imap.openConnection()
+  |> imap.login()
 inbox = imap.Mailbox("INBOX", "", '/')
 
 // Get the number of messages in the inbox.
-msgCount = imap.status(session, inbox).returnValue.messages
+msgCount = imap.status(session, inbox).messages
 
 // Select the default inbox.
 inbox |> imap.examine(session, _)
@@ -55,7 +55,7 @@ headers =
   iota(msgCount)
     |> map(id => "#" ~ toString(id + 1))
     |> map(id =>
-         imap.fetchFields(session, id, "date from subject").returnValue.lines
+         imap.fetchFields(session, id, "date from subject").lines
            |> map(hdr => fmtField(hdr, 40)))
     |> fold(fmtHeaders, "INBOX:\n")
 print(headers)

--- a/SIL/examples/list_mailboxes.sil
+++ b/SIL/examples/list_mailboxes.sil
@@ -8,11 +8,11 @@ creds = imap.ImapLogin(config.user, config.pass)
 server = imap.ImapServer(config.host, config.port)
 session =
   imap.Session(server, creds)
-  |> imap.openConnection().returnValue
-  |> imap.login().returnValue
+  |> imap.openConnection()
+  |> imap.login()
 
 // Get a list of all the mailboxes.
-list = imap.list(session).returnValue
+list = imap.list(session)
 
 // Close the session.
 imap.closeConnection(session)

--- a/SIL/examples/search.sil
+++ b/SIL/examples/search.sil
@@ -39,8 +39,8 @@ creds = imap.ImapLogin(config.user, config.pass)
 server = imap.ImapServer(config.host, config.port)
 session =
   imap.Session(server, creds)
-    |> imap.openConnection().returnValue
-    |> imap.login().returnValue
+    |> imap.openConnection()
+    |> imap.login()
 inbox = imap.Mailbox("support", "", '/')
 
 // Select the default inbox.
@@ -57,13 +57,13 @@ joinQuery(crita) => fold(crita[1:$], (str, crit) => str ~ " " ~ crit, crita[0])
 
 // Get each of the alerts and resolutions from the past week (13-19 May).
 alertMsgIds =
-  imap.search(session, joinQuery([fromCrit, afterCrit, alertCrit])).returnValue.ids
+  imap.search(session, joinQuery([fromCrit, afterCrit, alertCrit])).ids
 resolutionMsgIds =
-  imap.search(session, joinQuery([fromCrit, afterCrit, resCrit])).returnValue.ids
+  imap.search(session, joinQuery([fromCrit, afterCrit, resCrit])).ids
 
 // A function to get the alert ID from a message subject.
 getAlertId(msgId) => {
-  imap.fetchFields(session, toString(msgId), "subject").returnValue.lines[0]
+  imap.fetchFields(session, toString(msgId), "subject").lines[0]
     |> string.split()[$ - 1]
 }
 
@@ -89,8 +89,8 @@ report =
     |> map(alertId => {
          msgId = unresolvedAlertTable[alertId] |> toString
        in [ alertId
-          , imap.fetchFields(session, msgId, "date").returnValue.lines[0]
-          , imap.fetchText(session, msgId).returnValue.lines[0]
+          , imap.fetchFields(session, msgId, "date").lines[0]
+          , imap.fetchText(session, msgId).lines[0]
           ]
        })
     |> fold((outStr, tuple) => {

--- a/SIL/examples/util/source/app.d
+++ b/SIL/examples/util/source/app.d
@@ -12,7 +12,7 @@ int main(string[] args) {
         return 1;
     }
 
-    auto session = Session(ImapServer(args[1], "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(args[1], "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 

--- a/SIL/plug2.sil
+++ b/SIL/plug2.sil
@@ -6,10 +6,10 @@ print(login)
 server = imap.ImapServer("imap.fastmail.com","993")
 session = imap.Session(server,login,true,imap.Options(debugMode:true))
 //print("1")
-session=imap.openConnection(session).returnValue
+session=imap.openConnection(session)
 //print("2")
 // print(session.socket)
-session = imap.login(session).returnValue
+session = imap.login(session)
 //print("3")
 print(session)
 //print(imap.socketSecureWrite(session,"HELLO"))
@@ -29,24 +29,24 @@ print(result)
 print("======")
 
 // search all messages since 29 Jan 2019 and get UIDs
-result=imap.search(session,"SINCE 29-Jan-2019 HEADER Content-Type \"multipart/mixed\"").returnValue
+result=imap.search(session,"SINCE 29-Jan-2019 HEADER Content-Type \"multipart/mixed\"")
 print(result.value)
 
 // search all messages from GitHub since 29 Jan 2019 and get UIDs
-// result=imap.search(session,"SINCE 29-Jan-2012 FROM \"Github\"").returnValue
+// result=imap.search(session,"SINCE 29-Jan-2012 FROM \"Github\"")
 // print(result.value)
 
 id=result.ids.back
 // fetch one of the messages from above
-message_result = imap.fetchText(session, id |> text).returnValue
+message_result = imap.fetchText(session, id |> text)
 print(message_result.value)
 
 // just fetch the fields we care about
-fields_result=imap.fetchFields(session,id |> text,"FROM TO").returnValue
+fields_result=imap.fetchFields(session,id |> text,"FROM TO")
 print(fields_result.value)
 
 // fetch full RFC822 message and parse using arsd.email
-m=imap.fetchRFC822(session,id |> text).returnValue
+m=imap.fetchRFC822(session,id |> text)
 a=imap.attachments(m.message)[0]
 print(members(a))
 print(a.id)

--- a/example/source/app.d
+++ b/example/source/app.d
@@ -31,7 +31,7 @@ int main(string[] args) {
     auto login = ImapLogin(user, pass);
     auto imapServer = ImapServer(server, port);
 
-    auto session = Session(imapServer, login);
+    auto session = new Session(imapServer, login);
     session.options.debugMode = false;
     session = session.openConnection;
     session = session.login();

--- a/source/imap/searchquery.d
+++ b/source/imap/searchquery.d
@@ -192,7 +192,7 @@ string createQuery(SearchQuery[] searchQueries) {
 There is an implicit AND within a searchQuery. For NOT, set not within the query
 to be true - this applies to all the conditions within the query.
 `)
-auto searchQuery(ref Session session, string mailbox, SearchQuery searchQuery, string charset = null) {
+auto searchQuery(Session session, string mailbox, SearchQuery searchQuery, string charset = null) {
     import imap.namespace : Mailbox;
     import imap.request;
     select(session, Mailbox(mailbox));
@@ -204,7 +204,7 @@ The searchQueries are ORed together.  There is an implicit AND within a searchQu
 For NOT, set not within the query to be true - this applies to all the conditions within
 the query.
 `)
-auto searchQueries(ref Session session, string mailbox, SearchQuery[] searchQueries, string charset = null) {
+auto searchQueries(Session session, string mailbox, SearchQuery[] searchQueries, string charset = null) {
     import imap.namespace : Mailbox;
     import imap.request;
     select(session, Mailbox(mailbox));

--- a/source/imap/session.d
+++ b/source/imap/session.d
@@ -119,7 +119,7 @@ struct Options {
 }
 
 ///
-struct Session {
+final class Session {
     import imap.defines : ImapStatus;
     import imap.namespace;
     Options options;
@@ -144,7 +144,7 @@ struct Session {
     SSL* sslConnection;
     SSL_CTX* sslContext;
 
-    string toString() {
+    override string toString() {
         import std.array : Appender;
         import std.format : format;
         import std.conv : to;
@@ -171,17 +171,17 @@ struct Session {
         this.imapLogin = imapLogin;
     }
 
-    ref Session useStartTLS(bool useTLS = true) {
+    Session useStartTLS(bool useTLS = true) {
         this.options.startTLS = useTLS;
         return this;
     }
 
-    ref Session setSelected(Mailbox mailbox) {
+    Session setSelected(Mailbox mailbox) {
         this.selected = mailbox;
         return this;
     }
 
-    ref Session setStatus(ImapStatus status) {
+    Session setStatus(ImapStatus status) {
         this.status_ = status;
         return this;
     }

--- a/source/imap/socket.d
+++ b/source/imap/socket.d
@@ -47,7 +47,7 @@ SSL_CTX* getContext(string caFile, string caPath, string certificateFile, string
 
 
 /// Connect to mail server.
-Session openConnection(ref Session session) {
+Session openConnection(Session session) {
     import core.time : seconds;
     import std.format : format;
     import std.exception : enforce;
@@ -78,7 +78,7 @@ enum ProtocolSSL {
 }
 
 /// Initialize SSL/TLS connection.
-ref Session openSecureConnection(ref Session session) {
+Session openSecureConnection(Session session) {
     import std.exception : enforce;
     import imap.ssl;
 
@@ -131,7 +131,7 @@ bool isSSLError(int socketStatus) {
 }
 
 ///
-string sslConnectionError(ref Session session, int socketStatus) {
+string sslConnectionError(Session session, int socketStatus) {
     import std.format : format;
     import std.string : fromStringz;
     auto result = SSL_get_error(session.sslConnection, socketStatus);
@@ -171,7 +171,7 @@ private string sslConnectionSysCallError(int socketStatus) {
 }
 
 /// Disconnect from mail server.
-void closeConnection(ref Session session) {
+void closeConnection(Session session) {
     version (SSL) closeSecureConnection(session);
     if (session.socket !is null && session.socket.isAlive) {
         session.socket.close();
@@ -179,7 +179,7 @@ void closeConnection(ref Session session) {
 }
 
 /// Shutdown SSL/TLS connection.
-int closeSecureConnection(ref Session session) {
+int closeSecureConnection(Session session) {
     if (session.sslConnection) {
         SSL_shutdown(session.sslConnection);
         SSL_free(session.sslConnection);
@@ -208,7 +208,7 @@ auto result(T)(Status status, T value) {
 }
 
 /// Read data from socket.
-Result!string socketRead(ref Session session, Duration timeout, bool timeoutFail = true) {
+Result!string socketRead(Session session, Duration timeout, bool timeoutFail = true) {
     import std.experimental.logger : tracef;
     import std.exception : enforce;
     import std.format : format;
@@ -254,7 +254,7 @@ Result!string socketRead(ref Session session, Duration timeout, bool timeoutFail
 }
 
 ///
-bool isSSLReadError(ref Session session, int status) {
+bool isSSLReadError(Session session, int status) {
     switch (SSL_get_error(session.sslConnection, status)) {
         case SSL_ERROR_ZERO_RETURN,
             SSL_ERROR_SYSCALL,
@@ -276,7 +276,7 @@ bool isSSLReadError(ref Session session, int status) {
 }
 
 ///
-bool isTryAgain(ref Session session, int status) {
+bool isTryAgain(Session session, int status) {
     if (status > 0)
         return false;
     if (session.isSSLReadError(status))
@@ -297,7 +297,7 @@ bool isTryAgain(ref Session session, int status) {
 }
 
 /// Read data from a TLS/SSL connection.
-Result!string socketSecureRead(ref Session session) {
+Result!string socketSecureRead(Session session) {
     import std.experimental.logger : tracef;
     import std.exception : enforce;
     import std.conv : to;
@@ -321,7 +321,7 @@ Result!string socketSecureRead(ref Session session) {
 }
 
 ///
-string sslReadErrorMessage(ref Session session, int status) {
+string sslReadErrorMessage(Session session, int status) {
     import std.format : format;
     import std.string : fromStringz;
     import std.exception : enforce;
@@ -349,7 +349,7 @@ string sslReadErrorMessage(ref Session session, int status) {
 }
 
 /// Write data to socket.
-ssize_t socketWrite(ref Session session, string buf) {
+ssize_t socketWrite(Session session, string buf) {
     import std.experimental.logger : tracef;
     import std.exception : enforce;
     import std.format : format;
@@ -397,7 +397,7 @@ ssize_t socketWrite(ref Session session, string buf) {
 }
 
 /// Write data to a TLS/SSL connection.
-auto socketSecureWrite(ref Session session, string buf) {
+auto socketSecureWrite(Session session, string buf) {
     import std.experimental.logger : tracef;
     import std.string : fromStringz;
     import std.format : format;

--- a/source/imap/ssl.d
+++ b/source/imap/ssl.d
@@ -34,7 +34,7 @@ X509* getPeerCertificate(ref SSL context) {
 }
 
 @SILdoc("Get SSL/TLS certificate check it, maybe ask user about it and act accordingly.")
-Status getCert(ref Session session) {
+Status getCert(Session session) {
     import std.exception : enforce;
     X509* pcert = getPeerCertificate(*session.sslConnection);
     enforce(pcert !is null);

--- a/source/kaleidic/sil/plugin/imap/register.d
+++ b/source/kaleidic/sil/plugin/imap/register.d
@@ -402,7 +402,7 @@ string createQuery(SearchQuery[] searchQueries) {
 There is an implicit AND within a searchQuery. For NOT, set not within the query
 to be true - this applies to all the conditions within the query.
 `)
-auto searchQuery(ref Session session, string mailbox, SearchQuery searchQuery, string charset = null) {
+auto searchQuery(Session session, string mailbox, SearchQuery searchQuery, string charset = null) {
     import imap.namespace : Mailbox;
     import imap.request;
     select(session, Mailbox(mailbox));
@@ -414,7 +414,7 @@ The searchQueries are ORed together.  There is an implicit AND within a searchQu
 For NOT, set not within the query to be true - this applies to all the conditions within
 the query.
 `)
-auto searchQueries(ref Session session, string mailbox, SearchQuery[] searchQueries, string charset = null) {
+auto searchQueries(Session session, string mailbox, SearchQuery[] searchQueries, string charset = null) {
     import imap.namespace : Mailbox;
     import imap.request;
     select(session, Mailbox(mailbox));

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -90,7 +90,7 @@ private bool imapFail(F)(F fn) {
 
 private void testAuthentication(string host) {
     {
-        auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+        auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
         session = session.openConnection();
         session = session.login();
         imapEnforce(session.status == "ok", "auth", "SSL login failure.");
@@ -98,23 +98,23 @@ private void testAuthentication(string host) {
     }
     {
         // Logging in without opening a connection first should still work.
-        auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+        auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
         session = session.login();
         imapEnforce(session.status == "ok", "auth", "Login without connection failure.");
         imapEnforce(session.logout() == ImapStatus.ok, "auth", "Logout without connection failure.");
     }
     {
-        auto session = Session(ImapServer(host, "993"), ImapLogin("invalidusername", TestPass));
+        auto session = new Session(ImapServer(host, "993"), ImapLogin("invalidusername", TestPass));
         imapEnforce(imapFail(() => session.login()), "auth", "Bad username succeeded.");
     }
     {
-        auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, "incorrectpass"));
+        auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, "incorrectpass"));
         imapEnforce(imapFail(() => session.login()), "auth", "Bad password succeeded.");
     }
     {
         // The server is configured to reject plaintext password authentication over a non-encrypted
         // connection.
-        auto session = Session(ImapServer(host, "143"), ImapLogin(TestUser, TestPass), false);
+        auto session = new Session(ImapServer(host, "143"), ImapLogin(TestUser, TestPass), false);
         session = session.openConnection();
         imapEnforce(imapFail(() => session.login()), "auth", "Able to login without encryption.");
     }
@@ -123,7 +123,7 @@ private void testAuthentication(string host) {
 // -------------------------------------------------------------------------------------------------
 
 private void testMailboxOps(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -253,7 +253,7 @@ private void testMailboxOps(string host) {
 // - automatic subscription upon mailbox creation.
 
 private void testSubscriptions(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -393,7 +393,7 @@ private string[] exampleMessage2 =
 // - we're testing the flags and date is set properly down in `testFetch()` below.
 
 private void testAppend(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -422,7 +422,7 @@ private void testAppend(string host) {
 // -------------------------------------------------------------------------------------------------
 
 private void testStatus(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -457,7 +457,7 @@ private void testStatus(string host) {
 // - Removing mailbox when selected (will log you out).
 
 private void testSelect(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -487,7 +487,7 @@ private void testSelect(string host) {
 // - Try different mailbox hierarchies.
 
 private void testCopy(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -526,7 +526,7 @@ private void testCopy(string host) {
 // - Auto expunge in options.
 
 private void testStore(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -569,7 +569,7 @@ private void testStore(string host) {
 // - Check read-only state.  Not allowed to lose \Recent, nor to delete messages I assume.
 
 private void testExamine(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -598,7 +598,7 @@ private void testExamine(string host) {
 // -------------------------------------------------------------------------------------------------
 
 private void testCloseExpunge(string host) {
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -658,7 +658,7 @@ private void testCloseExpunge(string host) {
 private void testFetch(string host) {
     import std.algorithm: canFind;
 
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -749,7 +749,7 @@ private void testFetch(string host) {
 private void testSearch(string host) {
     import std.algorithm: canFind;
 
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 
@@ -791,7 +791,7 @@ private void testUid(string host) {
     import std.algorithm: canFind;
     import std.conv;
 
-    auto session = Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
+    auto session = new Session(ImapServer(host, "993"), ImapLogin(TestUser, TestPass));
     session = login(session);
     scope(exit) logout(session);
 


### PR DESCRIPTION
This is making Session a final class instead of a struct, which means the SIL wrapping will treat it as a reference type and we'll no longer need to use `returnValue` to deconstruct the results of most of the API.

This is obviously a non-backward compatible interface breaking change.

See #46 .