### PR TITLE
Update structured search query expressions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dub.selections.json
 
 libsymmetry-imap.*
+symmetry-imap-test-default
 example/imap-example
 
 tags

--- a/SIL/examples/search.sil
+++ b/SIL/examples/search.sil
@@ -28,7 +28,10 @@
 // number of outstanding alerts.
 
 import imap
+import * from imap.query
 import imap_config
+
+import dates
 import string
 
 // Get the configuration from the environment and command line.
@@ -46,20 +49,16 @@ inbox = imap.Mailbox("support", "", '/')
 // Select the default inbox.
 inbox |> imap.examine(session, _)
 
-// Specify some search criteria to be combined for different searches.
-fromCrit   = `FROM robot@example.com`
-alertCrit  = `SUBJECT "Alert: new issue"`
-resCrit    = `SUBJECT "Resolution: issue"`
-afterCrit  = `SENTSINCE 13-may-2020`
+// These criteria are common for both our searches.
+commonCrit = imap.Query()
+    |> and(from(`robot@example.com`))
+    |> and(sentSince(dates.Date(2020, 5, 13)))
 
-// Function to join search criteria.
-joinQuery(crita) => fold(crita[1:$], (str, crit) => str ~ " " ~ crit, crita[0])
-
-// Get each of the alerts and resolutions from the past week (13-19 May).
+// Get each of the alerts and resolutions from the past week (13-19 May 2020).
 alertMsgIds =
-  imap.search(session, joinQuery([fromCrit, afterCrit, alertCrit])).ids
+  imap.search(session, imap.Query(subject("Alert: new issue")) |> and(commonCrit)).ids
 resolutionMsgIds =
-  imap.search(session, joinQuery([fromCrit, afterCrit, resCrit])).ids
+  imap.search(session, imap.Query(subject("Resolution: issue")) |> and(commonCrit)).ids
 
 // A function to get the alert ID from a message subject.
 getAlertId(msgId) => {

--- a/SIL/search_test.sil
+++ b/SIL/search_test.sil
@@ -1,0 +1,35 @@
+import dates
+import imap
+import * from imap.query
+
+a = imap.Query()
+enforce(a.toString() == "ALL", "empty query")
+
+b = imap.Query()
+  |> and(seen())
+  |> and(subject("foo bar"))
+enforce(b.toString() == `SEEN SUBJECT "foo bar"`, "simple and")
+
+c = imap.Query()
+  |> and(to("alice"))
+  |> or(flagged())
+enforce(c.toString() == `OR TO "alice" FLAGGED`, "simple or")
+
+d = imap.Query()
+  |> not(deleted())
+  |> or(imap.Query() |> and(draft()) |> and(from("bob")))
+  |> andNot(before(dates.Date(2011, 11, 11)))
+enforce(d.toString() == `OR NOT DELETED (DRAFT FROM "bob") NOT BEFORE 11-Nov-2011`, "query expression")
+
+//e = imap.Query()
+//  |> and(larger(1234))
+//  |> andNot(uids(1))
+//  |> andNot(uidRange(2, 10))
+//  |> andNot(uids([12, uidRange(20, 30), 52]))
+//print(e.toString())
+//enforce(e.toString() == "LARGER 1234 NOT UID 1 NOT UID 2:10", "uids")
+
+f = imap.Query()
+  |> and(larger(1234))
+  |> or(keyword("abracadabra"))
+enforce(f.toString() == "OR LARGER 1234 KEYWORD abracadabra", "keyword expression")

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,9 +1,9 @@
 name "symmetry-imap"
 description "IMAP client library"
 dependency "openssl" version="~>1.1.6+1.0.1g"
-dependency "arsd-official:email" version="~master"
-dependency "requests" version="*"
-dependency "asdf" version="~master"
+dependency "arsd-official:email" version="~>8.5"
+dependency "requests" version="~>2.0"
+dependency "asdf" version="~>0.6"
 
 license "MIT"
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,33 +1,26 @@
 name "symmetry-imap"
 description "IMAP client library"
-dependency "openssl" version="~>1.1.6+1.0.1g"
-dependency "arsd-official:email" version="~>8.5"
-dependency "requests" version="~>2.0"
-dependency "asdf" version="~>0.6"
-
 license "MIT"
-
-versions "SSL" "OPENSSL_NO_SRP"
-
+dependency "sumtype" version="~>0.9.3"
+dependency "arsd-official:email" version="~>8.5"
+dependency "openssl" version="~>1.1.6"
+dependency "requests" version="~>2"
+dependency "asdf" version="~>0.6"
 libs "ssl" "crypto" platform="posix"
-
+versions "SSL" "OPENSSL_NO_SRP"
 configuration "default" {
 	targetType "library"
 	versions "MoveSanity"
 }
-
 configuration "sil-library" {
-	dependency "sil-lang" version="*" optional=true
-	dependency "pegged" version="*" optional=true
+	dependency "sil-lang" version=">=0.0.0" optional=true
+	dependency "pegged" version=">=0.0.0" optional=true
 	targetType "library"
 	versions "MoveSanity" "SIL"
 }
-
-// dub insists on looking for sil-lang even if building
-// the default configuration!
 configuration "plugin" {
-	dependency "sil-lang" version="*" optional=true
-	dependency "pegged" version="*" optional=true
+	dependency "sil-lang" version=">=0.0.0" optional=true
+	dependency "pegged" version=">=0.0.0" optional=true
 	targetType "dynamicLibrary"
-	versions "SIL_Plugin" "SIL" "MoveSanity"  //"Trace"
+	versions "SIL_Plugin" "SIL" "MoveSanity"
 }

--- a/example/dub.sdl
+++ b/example/dub.sdl
@@ -6,7 +6,7 @@ license "proprietary"
 dependency "symmetry-imap" path="../"
 subConfiguration "symmetry-imap" "default"
 targetType "executable"
-dependency "arsd-official:email" version="~master"
+dependency "arsd-official:email" version="~>8.5"
 
 configuration "appveyor" {
 	libs "libssl" "libcrypto" platform="windows"

--- a/example/source/app.d
+++ b/example/source/app.d
@@ -47,8 +47,10 @@ int main(string[] args) {
     writeln("--- Search result IDs: ", searchResult.ids);
 
     // search all messages from GitHub since 29 Jan 2019 and get UIDs using high level query interface
-    SearchQuery query = { since : Date(2019, 1, 29), fromContains : "GitHub" };
-    searchResult = session.searchQuery("INBOX", query);
+    auto query = new SearchQuery()
+        .and(DateTerm(DateTerm.When.Since, Date(2019, 1, 29)))
+        .and(FieldTerm(FieldTerm.Field.From, "GitHub"));
+    searchResult = session.search(query);
     writeln("--- Structured 'since:Date(2019,1,29),fromContains:\"GitHub\"' search results:");
     writeln(searchResult.value);
 

--- a/source/imap/searchquery.d
+++ b/source/imap/searchquery.d
@@ -1,236 +1,439 @@
 ///
 module imap.searchquery;
 
+import sumtype;
+import std.format : format;
+import std.datetime : Date;
+
 import imap.defines;
 import imap.socket;
 import imap.session : Session;
 import imap.sildoc : SILdoc;
 
-import core.time : Duration;
-import std.datetime : Date;
+// -------------------------------------------------------------------------------------------------
 
-struct SearchQuery {
-    @SILdoc("not flag if applied inverts the whole query")
-    @("NOT")
-    bool not;
-
-    ImapFlag[] flags;
-
-    @("FROM")
-    string fromContains;
-
-    @("CC")
-    string ccContains;
-
-    @("BCC")
-    string bccContains;
-
-    @("TO")
-    string toContains;
-
-    @("SUBJECT")
-    string subjectContains;
-
-    @("BODY")
-    string bodyContains;
-
-    @("TEXT")
-    string textContains;
-
-    @("BEFORE")
-    Date beforeDate;
-
-    @("HEADER")
-    string[string] headerFieldContains;
-
-    @("KEYWORD")
-    string[] hasKeyword;
-
-    @("SMALLER")
-    ulong smallerThanBytes;
-
-    @("LARGER")
-    ulong largerThanBytes;
-
-    @("NEW")
-    bool isNew;
-
-    @("OLD")
-    bool isOld;
-
-    @("ON")
-    Date onDate;
-
-    @("SENTBEFORE")
-    Date sentBefore;
-
-    @("SENTON")
-    Date sentOn;
-
-    @("SENTSINCE")
-    Date sentSince;
-
-    @("SINCE")
-    Date since;
-
-    @("UID")
-    ulong[] uniqueIdentifiers;
-
-    @("UID")
-    UidRange[] uniqueIdentifierRanges;
-
-    string applyNot(string s) {
-        import std.string : join;
-
-        return not ? ("NOT " ~ s) : s;
+final class SearchQuery {
+    this(SearchExpr* expr = null) {
+        query = expr;
     }
 
-    template isSILdoc(alias T) {
-        enum isSILdoc = is(typeof(T) == SILdoc);
+    SearchQuery and(SearchExpr* term) {
+        return applyBinOp('&', term);
+    }
+    SearchQuery and(SearchQuery other) {
+        return applyBinOp('&', other.query);
     }
 
-    void toString(scope void delegate(const(char)[]) sink) {
-        import std.range : dropOne;
-        import std.string : toUpper;
-        import std.conv : to;
-        import std.meta : Filter, templateNot;
-        import std.traits : isFunction;
-        foreach (flag; flags) {
-            sink(applyNot(flag.to!string.dropOne.toUpper));
-        }
-        static foreach (M; Filter!(templateNot!isFunction, __traits(allMembers, typeof(this)))) {
-            {
-                enum udas = Filter!(templateNot!isSILdoc, __traits(getAttributes, __traits(getMember, this, M)));
-                static if (udas.length > 0) {
-                    alias T = typeof(__traits(getMember, this, M));
-                    enum name = udas[0].to!string;
-                    auto v = __traits(getMember, this, M);
-                    static if (is(T == string)) {
-                        if (v.length > 0) {
-                            sink(applyNot(name));
-                            sink(" \"");
-                            sink(v);
-                            sink("\" ");
-                        }
-                    } else static if (is(T == Date)) {
-                        if (v != Date.init) {
-                            sink(applyNot(name));
-                            sink(" ");
-                            sink(__traits(getMember, this, M).rfcDate);
-                            sink(" ");
-                        }
-                    } else static if (is(T == bool) && (name != "NOT")) {
-                        if (v) {
-                            sink(applyNot(name));
-                            sink(" ");
-                        }
-                    } else static if (is(T == string[string])) {
-                        foreach (entry; __traits(getMember, this, M).byKeyValue) {
-                            sink(applyNot(name));
-                            sink(" ");
-                            sink(entry.key);
-                            sink(" \"");
-                            sink(entry.value);
-                            sink("\" ");
-                        }
-                    } else static if (is(T == string[])) {
-                        foreach (entry; __traits(getMember, this, M)) {
-                            sink(applyNot(name));
-                            sink(" \"");
-                            sink(entry);
-                            sink("\" ");
-                        }
-                    } else static if (is(T == ulong[])) {
-                        if (v.length > 0) {
-                            sink(applyNot(name));
-                            sink(" ");
-                            auto len = __traits(getMember, this, M).length;
-                            foreach (i, entry; __traits(getMember, this, M)) {
-                                sink(entry.to!string);
-                                if (i != len - 1)
-                                    sink(",");
-                            }
-                            static if (name == "UID") {
-                                if (len > 0 && uniqueIdentifierRanges.length > 0)
-                                    sink(",");
-                                len = uniqueIdentifierRanges.length;
-                                foreach (i, entry; uniqueIdentifierRanges) {
-                                    sink(entry.to!string);
-                                    if (i != len - 1)
-                                        sink(",");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    SearchQuery or(SearchExpr* term) {
+        // Strictly speaking the implicit 'ALL' term should be ORed with a unit arg, but that
+        // wouldn't really be helpful and is very likely not what the user wants.
+        return applyBinOp('|', term);
     }
+    SearchQuery or(SearchQuery other) {
+        return applyBinOp('|', other.query);
+    }
+
+    SearchQuery not(SearchExpr* term) {
+        assert(query is null, "Cannot apply .not() to existing queries!  Use andNot() or orNot().");
+        query = new SearchExpr(SearchOp('!', term, null));
+        return this;
+    }
+
+    SearchQuery andNot(SearchExpr* term) {
+        return applyBinOp('&', new SearchExpr(SearchOp('!', term, null)));
+    }
+    SearchQuery andNot(SearchQuery other) {
+        return applyBinOp('&', new SearchExpr(SearchOp('!', other.query, null)));
+    }
+
+    SearchQuery orNot(SearchExpr* term) {
+        return applyBinOp('|', new SearchExpr(SearchOp('!', term, null)));
+    }
+    SearchQuery orNot(SearchQuery other) {
+        return applyBinOp('|', new SearchExpr(SearchOp('!', other.query, null)));
+    }
+
+    override string toString() {
+        return searchExprToString(query);
+    }
+    alias toString this;
+
+    SearchQuery applyBinOp(char op, SearchExpr* newTerm) {
+        if (query is null)
+            query = newTerm;
+        else
+            query = new SearchExpr(SearchOp(op, query, newTerm));
+        return this;
+    }
+
+    SearchExpr* query;
 }
 
-@SILdoc(`Generate query string to serch the selected mailbox according to the supplied criteria.
-This string may be passed to imap.search.
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
-The searchQueries are ORed together.  There is an implicit AND within a searchQuery
-For NOT, set not within the query to be true - this applies to all the conditions within
-the query.
-`)
-string createQuery(SearchQuery[] searchQueries) {
-    import std.range : chain, repeat;
+string searchExprToString(SearchExpr* expr) {
     import std.algorithm : map;
-    import std.string : join, strip;
-    import std.conv : to;
+    import std.array : join;
 
-    if (searchQueries.length == 0)
+    if (expr is null) {
         return "ALL";
-
-    return chain("OR".repeat(searchQueries.length - 1),
-            searchQueries.map!(q => q.to!string.strip)).join(" ").strip;
+    }
+    return (*expr).match!(
+        (FlagTerm term)    => cast(string)term.flag,
+        (KeywordTerm term) => format!"%sKEYWORD %s"(term.negated ? "UN" : "", term.keyword),
+        (FieldTerm term)   => format!`%s "%s"`(cast(string)term.field, term.term),
+        (HeaderTerm term)  => format!`HEADER %s "%s"`(term.header, term.term),
+        (DateTerm term)    => format!"%s %s"(cast(string)term.when, rfcDateStr(term.date)),
+        (SizeTerm term)    => format!"%s %d"(cast(string)term.relation, term.size),
+        (UidSeqTerm term)  => format!"UID %s"(term.sequences.map!(s => s.toString()).join(",")),
+        (SearchOp expr)    => searchOpToString(expr),
+    );
 }
 
-@SILdoc(`Search selected mailbox according to the supplied search criteria.
-There is an implicit AND within a searchQuery. For NOT, set not within the query
-to be true - this applies to all the conditions within the query.
-`)
-auto searchQuery(Session session, string mailbox, SearchQuery searchQuery, string charset = null) {
-    import imap.namespace : Mailbox;
-    import imap.request;
-    select(session, Mailbox(mailbox));
-    return search(session, createQuery([searchQuery]), charset);
-}
-
-@SILdoc(`Search selected mailbox according to the supplied search criteria.
-The searchQueries are ORed together.  There is an implicit AND within a searchQuery
-For NOT, set not within the query to be true - this applies to all the conditions within
-the query.
-`)
-auto searchQueries(Session session, string mailbox, SearchQuery[] searchQueries, string charset = null) {
-    import imap.namespace : Mailbox;
-    import imap.request;
-    select(session, Mailbox(mailbox));
-    return search(session, createQuery(searchQueries), charset);
-}
-
-@SILdoc("Convert a SIL date to an RFC-2822 / IMAP Date string")
-string rfcDate(Date date) {
-    import std.format : format;
-    import std.conv : to;
-    import std.string : capitalize;
-    return format!"%02d-%s-%04d"(date.day, date.month.to!string.capitalize, date.year);
-}
-
-
-struct UidRange {
-    long start = -1;
-    long end = -1;
-
-    string toString() {
-        import std.string : format;
-        import std.conv : to;
-
-        return format!"%s:%s"(
-            (start == -1) ? 0 : start,
-            (end == -1) ? "*" : end.to!string
-        );
+string searchOpToString(SearchOp op) {
+    switch (op.op) {
+        case '!': return notOpToString(op.lhs);
+        case '&': return format!"%s %s"(searchExprToString(op.lhs), searchExprToString(op.rhs));
+        case '|': return orOpToString(op.lhs, op.rhs);
+        default:  assert(false, "Unknown search operation.");
     }
 }
+
+string notOpToString(SearchExpr* expr) {
+    string exprStr = searchExprToString(expr);
+    if (isBinaryOp(expr)) {
+        return format!"NOT (%s)"(exprStr);
+    }
+    return format!"NOT %s"(exprStr);
+}
+
+string orOpToString(SearchExpr* lhs, SearchExpr* rhs) {
+    string lhsStr = searchExprToString(lhs);
+    if (isBinaryOp(lhs)) {
+        lhsStr = format!"(%s)"(lhsStr);
+    }
+    string rhsStr = searchExprToString(rhs);
+    if (isBinaryOp(rhs)) {
+        rhsStr = format!"(%s)"(rhsStr);
+    }
+    return format!"OR %s %s"(lhsStr, rhsStr);
+}
+
+bool isBinaryOp(SearchExpr* expr) {
+    return (*expr).match!(
+        (SearchOp op) => op.op == '&' || op.op == '|',
+        (_)           => false,
+    );
+}
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+import std.typecons : Tuple;
+
+alias SearchExpr = SumType!(
+    FlagTerm,
+    KeywordTerm,
+    FieldTerm,
+    HeaderTerm,
+    DateTerm,
+    SizeTerm,
+    UidSeqTerm,
+
+    // '!' == NOT, '&' == AND, '|' == OR.
+    Tuple!(char, "op", This*, "lhs", This*, "rhs"),
+);
+
+alias SearchOp = SearchExpr.Types[7];
+
+struct FlagTerm {
+    enum Flag : string {
+        Answered   = "ANSWERED",
+        Deleted    = "DELETED",
+        Draft      = "DRAFT",
+        Flagged    = "FLAGGED",
+        New        = "NEW",
+        Old        = "OLD",
+        Recent     = "RECENT",
+        Seen       = "SEEN",
+        Unanswered = "UNANSWERED",
+        Undeleted  = "UNDELETED",
+        Undraft    = "UNDRAFT",
+        Unflagged  = "UNFLAGGED",
+        Unseen     = "UNSEEN",
+    }
+    Flag flag;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+struct KeywordTerm {
+    string keyword;
+    bool negated = false;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+struct FieldTerm {
+    enum Field : string {
+        Bcc     = "BCC",
+        Body    = "BODY",
+        Cc      = "CC",
+        From    = "FROM",
+        Subject = "SUBJECT",
+        Text    = "TEXT",
+        To      = "TO",
+    }
+    Field field;
+    string term;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+struct HeaderTerm {
+    string header;
+    string term;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+struct DateTerm {
+    enum When : string {
+        Before     = "BEFORE",
+        On         = "ON",
+        SentBefore = "SENTBEFORE",
+        SentOn     = "SENTON",
+        SentSince  = "SENTSINCE",
+        Since      = "SINCE",
+    }
+    When when;
+    Date date;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+string rfcDateStr(Date date) {
+    return format!"%d-%s-%d"(date.day,
+                             ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                             "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][date.month - 1],
+                             date.year);
+}
+
+struct SizeTerm {
+    enum Relation : string {
+        Larger  = "LARGER",
+        Smaller = "SMALLER",
+    }
+    Relation relation;
+    int size;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+struct UidSeqTerm {
+    struct Range {
+        // This is a little unintuitive; if length is 0 then there's a single value: start, else
+        // it's a range *including* start+length.  I.e., if length is 1, then it's a range of start
+        // and start+1 (2 values).
+        int start, length = 0;
+
+        invariant (start >= 1 && length >= 0);
+
+        string toString() {
+            if (length == 0)
+                return format!"%d"(start);
+            return format!"%d:%d"(start, start + length);
+        }
+    }
+    Range[] sequences;
+
+    @property SearchExpr* toExpr() {
+        return new SearchExpr(this);
+    }
+    alias toExpr this;
+}
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+unittest {
+    assert(new SearchQuery().toString == "ALL");
+
+    void termTest(T)(T term, string expected) {
+        import std.stdio : writeln;
+
+        auto got = new SearchQuery(term).toString();
+        if (got != expected) {
+            writeln("FAILED MATCH:");
+            writeln("expecting: ", expected);
+            writeln("got:       ", got);
+        }
+        assert(new SearchQuery(new SearchExpr(term)).toString() == expected);
+    }
+
+    termTest(FlagTerm(FlagTerm.Flag.New), "NEW");
+    termTest(KeywordTerm("foobar"), "KEYWORD foobar");
+    termTest(FieldTerm(FieldTerm.Field.Cc, "alice"), `CC "alice"`);
+    termTest(HeaderTerm("X-SPAM", "high"), `HEADER X-SPAM "high"`);
+    termTest(DateTerm(DateTerm.When.Since, Date(2007, 7, 1)), "SINCE 1-Jul-2007");
+    termTest(SizeTerm(SizeTerm.Relation.Larger, 12345), "LARGER 12345");
+    termTest(UidSeqTerm([UidSeqTerm.Range(1, 3), UidSeqTerm.Range(7), UidSeqTerm.Range(33, 100)]), "UID 1:4,7,33:133");
+}
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+unittest {
+    import std.exception;
+    import core.exception;
+
+    void queryTest(Q)(Q query, string expected) {
+        import std.stdio : writeln;
+
+        auto got = query.toString();
+        if (got != expected) {
+            writeln("FAILED MATCH:");
+            writeln("expecting: ", expected);
+            writeln("got:       ", got);
+        }
+        assert(query.toString() == expected);
+    }
+
+    // AND.
+    auto sq00 =
+        new SearchQuery(FlagTerm(FlagTerm.Flag.Flagged))
+        .and(FieldTerm(FieldTerm.Field.Subject, "welcome"));
+    queryTest(sq00, `FLAGGED SUBJECT "welcome"`);
+    auto sq01 =
+        new SearchQuery()
+        .and(FlagTerm(FlagTerm.Flag.Unflagged))
+        .and(FieldTerm(FieldTerm.Field.Subject, "welcome"));
+    queryTest(sq01, `UNFLAGGED SUBJECT "welcome"`);
+    auto sq02 =
+        new SearchQuery()
+        .and(FlagTerm(FlagTerm.Flag.Unflagged))
+        .and(FieldTerm(FieldTerm.Field.Subject, "welcome"))
+        .and(KeywordTerm("quux", true));
+    queryTest(sq02, `UNFLAGGED SUBJECT "welcome" UNKEYWORD quux`);
+
+    // OR.
+    auto sq10 =
+        new SearchQuery(DateTerm(DateTerm.When.On, Date(2012, 12, 12)))
+        .or(SizeTerm(SizeTerm.Relation.Smaller, 1212));
+    queryTest(sq10, "OR ON 12-Dec-2012 SMALLER 1212");
+    auto sq11 =
+        new SearchQuery()
+        .or(DateTerm(DateTerm.When.On, Date(2012, 12, 12)))
+        .or(SizeTerm(SizeTerm.Relation.Smaller, 1212));
+    queryTest(sq11, "OR ON 12-Dec-2012 SMALLER 1212");
+    auto sq12 =
+        new SearchQuery()
+        .or(DateTerm(DateTerm.When.On, Date(2012, 12, 12)))
+        .or(SizeTerm(SizeTerm.Relation.Smaller, 1212))
+        .or(UidSeqTerm([UidSeqTerm.Range(40, 10)]));
+    queryTest(sq12, "OR (OR ON 12-Dec-2012 SMALLER 1212) UID 40:50");
+
+    // NOT/AND-NOT/OR-NOT.
+    auto sq20 =
+        new SearchQuery()
+        .not(FieldTerm(FieldTerm.Field.To, "bob"));
+    queryTest(sq20, `NOT TO "bob"`);
+    auto sq21 =
+        new SearchQuery()
+        .and(FieldTerm(FieldTerm.Field.To, "bob"))
+        .andNot(FieldTerm(FieldTerm.Field.From, "carlos"));
+    queryTest(sq21, `TO "bob" NOT FROM "carlos"`);
+    auto sq22 =
+        new SearchQuery()
+        .and(FieldTerm(FieldTerm.Field.To, "bob"))
+        .orNot(FieldTerm(FieldTerm.Field.From, "carlos"));
+    queryTest(sq22, `OR TO "bob" NOT FROM "carlos"`);
+    auto sq23 =
+        new SearchQuery()
+        .or(FieldTerm(FieldTerm.Field.To, "bob"))
+        .orNot(FieldTerm(FieldTerm.Field.From, "carlos"));
+    queryTest(sq23, `OR TO "bob" NOT FROM "carlos"`);
+    auto sq24 =
+        new SearchQuery()
+        .not(FieldTerm(FieldTerm.Field.To, "bob"))
+        .orNot(FieldTerm(FieldTerm.Field.From, "carlos"));
+    queryTest(sq24, `OR NOT TO "bob" NOT FROM "carlos"`);
+    assertThrown!AssertError(new SearchQuery()
+                 .and(FieldTerm(FieldTerm.Field.To, "bob"))
+                 .not(FieldTerm(FieldTerm.Field.From, "carlos")));
+    version(none) {
+        // This would be nice, but special casing FlagTerm in this way would require too much guff.
+    auto sq25 =
+        new SearchQuery()
+        .not(FlagTerm(FlagTerm.Flag.Answered))
+        .andNot(FlagTerm(FlagTerm.Flag.Deleted))
+        .andNot(FlagTerm(FlagTerm.Flag.Draft))
+        .andNot(FlagTerm(FlagTerm.Flag.Flagged))
+        .andNot(FlagTerm(FlagTerm.Flag.New))
+        .andNot(FlagTerm(FlagTerm.Flag.Old))
+        .andNot(FlagTerm(FlagTerm.Flag.Recent))
+        .andNot(FlagTerm(FlagTerm.Flag.Seen))
+        .andNot(KeywordTerm("xyzzy"));
+    queryTest(sq25, `UNANSWERED UNDELETED UNDRAFT UNFLAGGED NOT NEW RECENT OLD UNSEEN UNKEYWORD xyzzy`);
+    }
+
+    // DEEP NESTING.
+    // a && (b || c) && d
+    auto sq30_BorC =
+        new SearchQuery(FlagTerm(FlagTerm.Flag.Draft))
+        .or(FlagTerm(FlagTerm.Flag.Flagged));
+    auto sq30 =
+        new SearchQuery()
+        .and(FieldTerm(FieldTerm.Field.To, "alice"))
+        .and(sq30_BorC)
+        .and(FieldTerm(FieldTerm.Field.Subject, "wip"));
+    queryTest(sq30, `TO "alice" OR DRAFT FLAGGED SUBJECT "wip"`);
+    // a || (b && c) || d
+    auto sq31_BandC =
+        new SearchQuery(FlagTerm(FlagTerm.Flag.Draft))
+        .and(FlagTerm(FlagTerm.Flag.Flagged));
+    auto sq31 =
+        new SearchQuery()
+        .or(FieldTerm(FieldTerm.Field.To, "alice"))
+        .or(sq31_BandC)
+        .or(FieldTerm(FieldTerm.Field.Subject, "wip"));
+    queryTest(sq31, `OR (OR TO "alice" (DRAFT FLAGGED)) SUBJECT "wip"`);
+    // a || !(b || c) || d  (Using De Morgan we *could* rewrite to a || (b && c) || d).
+    auto sq32_BorC =
+        new SearchQuery(FlagTerm(FlagTerm.Flag.Draft))
+        .or(FlagTerm(FlagTerm.Flag.Flagged));
+    auto sq32 =
+        new SearchQuery()
+        .or(FieldTerm(FieldTerm.Field.To, "alice"))
+        .orNot(sq32_BorC)
+        .or(FieldTerm(FieldTerm.Field.Subject, "wip"));
+    queryTest(sq32, `OR (OR TO "alice" NOT (OR DRAFT FLAGGED)) SUBJECT "wip"`);
+    // a && !(b || c) && d
+    auto sq33_BorC =
+        new SearchQuery(FlagTerm(FlagTerm.Flag.Draft))
+        .or(FlagTerm(FlagTerm.Flag.Flagged));
+    auto sq33 =
+        new SearchQuery()
+        .and(FieldTerm(FieldTerm.Field.To, "alice"))
+        .andNot(sq33_BorC)
+        .and(FieldTerm(FieldTerm.Field.Subject, "wip"));
+    queryTest(sq33, `TO "alice" NOT (OR DRAFT FLAGGED) SUBJECT "wip"`);
+}
+
+// -------------------------------------------------------------------------------------------------
+

--- a/source/imap/sil.d
+++ b/source/imap/sil.d
@@ -1,6 +1,8 @@
 module imap.sil;
 
-version (SIL) { public import kaleidic.sil.lang.types : SILdoc; } else {
+version (SIL) {
+    public import kaleidic.sil.lang.typing.types : SILdoc;
+} else {
     struct SILdoc {
         string value;
     }

--- a/source/jmap/api.d
+++ b/source/jmap/api.d
@@ -4,8 +4,8 @@ static import jmap.types;
 
 version (SIL) {
     import kaleidic.sil.lang.handlers : Handlers;
-    import kaleidic.sil.lang.types : Variable, Function, SILdoc;
-    import kaleidic.sil.lang.builtins : Maybe;
+    import kaleidic.sil.lang.typing.types : Variable, Function, SILdoc;
+    import kaleidic.sil.lang.typing.builtins : Maybe;
 
     void registerHandlersJmap(ref Handlers handlers) {
         import std.meta : AliasSeq;

--- a/source/jmap/types.d
+++ b/source/jmap/types.d
@@ -4,8 +4,8 @@ import core.time : seconds;
 import std.typecons : Nullable;
 
 version (SIL) :
-    import kaleidic.sil.lang.types : Variable, Function, SILdoc;
-import kaleidic.sil.lang.json : toVariable, toJsonString;
+    import kaleidic.sil.lang.typing.types : Variable, Function, SILdoc;
+import kaleidic.sil.lang.typing.json : toVariable, toJsonString;
 import std.datetime : DateTime;
 import asdf;
 

--- a/source/kaleidic/sil/plugin/imap/register.d
+++ b/source/kaleidic/sil/plugin/imap/register.d
@@ -4,7 +4,7 @@ import imap.set;
 version (SIL) :
 
     import kaleidic.sil.lang.handlers : Handlers;
-import kaleidic.sil.lang.types : Variable, Function, SILdoc;
+import kaleidic.sil.lang.typing.types : Variable, Function, SILdoc;
 import std.meta : AliasSeq;
 
 version (SIL_Plugin) {

--- a/source/kaleidic/sil/plugin/imap/register.d
+++ b/source/kaleidic/sil/plugin/imap/register.d
@@ -13,11 +13,10 @@ version (SIL_Plugin) {
     mixin pluginImpl!registerImap;
 }
 
+import std.socket;
+
 import imap.defines;
 import imap.socket;
-import imap.session : Session;
-
-import std.socket;
 
 import arsd.email : MimeContainer;
 
@@ -27,65 +26,186 @@ void registerImap(ref Handlers handlers) {
     import imap.request;
     import imap.response;
     import imap.namespace;
-    import deimos.openssl.ssl;
-    import deimos.openssl.evp;
+    import imap.searchquery;
     import arsd.email : IncomingEmailMessage, RelayInfo, ToType, EmailMessage, MimePart;
 
+    // Register for imap.*.
     {
         handlers.openModule("imap");
         scope (exit) handlers.closeModule();
 
-        static foreach (T; AliasSeq!(MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
-                                     Status, FlagResult, SearchResult, Session, ProtocolSSL,
-                                     ImapServer, ImapLogin, StatusResult, BodyResponse,
-                                     ListResponse, ListEntry, IncomingEmailMessage, RelayInfo,
-                                     ToType, EmailMessage, MimePart, Options, MimeContainer_,
-                                     MimeAttachment, SearchResultType,
-                                     StoreMode // proxy from imap not arsd
+        static foreach (T; AliasSeq!(BodyResponse, EmailMessage, FlagResult, ImapLogin, ImapResult,
+                                     ImapServer, ImapStatus, IncomingEmailMessage, ListEntry,
+                                     ListResponse, Mailbox, MailboxList, MimeAttachment,
+                                     MimeContainer_, MimePart, Options, ProtocolSSL, RelayInfo,
+                                     Result!string, SearchResult, SearchResultType, Session, Status,
+                                     StatusResult, StoreMode, ToType
                                     )) {
             handlers.registerType!T;
         }
 
-        handlers.registerType!(Set!Capability)("Capabilities");
+        static foreach (F; AliasSeq!(append, attachments, close, closeConnection, copy, create,
+                                     delete_, esearch, examine, expunge, fetchDate, fetchFast,
+                                     fetchFields, fetchFlags, fetchHeader, fetchPart, fetchRFC822,
+                                     fetchSize, fetchStructure, fetchText, idle, list, login,
+                                     logout, lsub, move, moveUIDs, multiMove, multiSearch, noop,
+                                     openConnection, rename, select, status, store, subscribe,
+                                     unsubscribe, writeBinaryString,
+                                     )) {
+            handlers.registerHandler!F;
+        }
 
+        handlers.registerType!Socket;
+        handlers.registerType!(Set!Capability)("Capabilities");
         handlers.registerType!(Set!ulong)("UidSet");
+
         handlers.registerHandler!(addSet!ulong)("addUidSet");
         handlers.registerHandler!(removeSet!ulong)("removeUidSet");
 
-        // FIXME - finish and add append
-        static foreach (F; AliasSeq!(noop, login, logout, status, examine, select, close, expunge,
-                                     list, lsub, search, fetchFast, fetchFlags, fetchDate,
-                                     fetchSize, fetchStructure, fetchHeader, fetchText, fetchFields,
-                                     fetchPart, store, copy, create, delete_, rename, subscribe,
-                                     unsubscribe, idle, openConnection, closeConnection,
-                                     fetchRFC822, attachments, writeBinaryString, esearch,
-                                     multiSearch, move, multiMove, moveUIDs,
-                        )) {
-            handlers.registerHandler!F;
-        }
-        handlers.registerType!Socket;
+        handlers.registerType!SearchQuery("Query");
+        handlers.registerHandlerOverloads!(
+            ((Session session, SearchQuery query) => session.search(query)),
+            ((Session session, string str) => session.search(str)),
+        )("search");
 
         import jmap : registerHandlersJmap;
         handlers.registerHandlersJmap();
     }
 
+    // Register for imap.query.*.
     {
-        handlers.openModule("ssl");
+        handlers.openModule("imap.query");
         scope (exit) handlers.closeModule();
-        static foreach (T; AliasSeq!(EVP_MD, SSL_))
-            handlers.registerType!T;
-        handlers.registerType!X509_("X509");
+
+        auto opDoc = SILdoc(`Compose search query terms with boolean operations. A query expression can be
+created with 'and', 'or' and 'not', and also with 'andNot' and 'orNot'.
+
+Query terms are specific filter criteria such as 'old()' or
+'from("alice@example.com")'.
+
+  E.g.,
+  // Equivalent to (flagged OR subject contains "urgent") AND NOT from "gmail.com".
+  query = imap.Query()
+      |> and(flagged())
+      |> or(subject("urgent"))
+      |> andNot(from("gmail.com"))
+
+This query can then be passed to 'imap.search()'.
+
+When applying an or() operator the passed argument is OR'd with whatever is
+already in the query.  Queries may be nested to enforce a precedence or to
+essentially introduce parentheses.
+
+  E.g.,
+  // Equivalent to NOT flagged AND (seen OR recent) AND from "barry"
+  query = imap.Query()
+      |> not(flagged())
+      |> and(imap.Query() |> or(seen()) |> or(recent()))
+      |> and(from("barry"))
+
+NOTE: These operators modify the Query in-place.  Be careful when re-using sub-queries:
+
+  a = imap.Query(recent())    // 'a' matches 'recent'.
+  b = a |> and(flagged())     // *Both* 'a' and 'b' now match ("recent" AND "flagged").
+
+To use these operators and terms as shown above, use:
+
+  import imap
+  import * from imap.query`);
+
+        // Boolean ops.
+        handlers.registerHandlerOverloads!(
+            (SearchQuery this_, SearchExpr* expr) => this_.and(expr),
+            (SearchQuery this_, SearchQuery other) => this_.and(other),
+        )("and", opDoc);
+        handlers.registerHandlerOverloads!(
+            (SearchQuery this_, SearchExpr* expr) => this_.or(expr),
+            (SearchQuery this_, SearchQuery other) => this_.or(other),
+        )("or", opDoc);
+        handlers.registerHandler!((SearchQuery this_, SearchExpr* expr) => this_.not(expr))("not", opDoc);
+        handlers.registerHandlerOverloads!(
+            (SearchQuery this_, SearchExpr* expr) => this_.andNot(expr),
+            (SearchQuery this_, SearchQuery other) => this_.andNot(other),
+        )("andNot", opDoc);
+        handlers.registerHandlerOverloads!(
+            (SearchQuery this_, SearchExpr* expr) => this_.orNot(expr),
+            (SearchQuery this_, SearchQuery other) => this_.orNot(other),
+        )("orNot", opDoc);
+
+        auto termDoc = SILdoc(`Search terms used to build a query to pass to imap.search().  Also see imap.query
+functions, e.g., imap.query.and().
+
+Flag terms, where the flag is set or unset:
+    answered(), deleted(), draft(), flagged(), new(), old(), recent(), seen(),
+    unanswered(), undeleted(), undraft(), unflagged, unseen(), keyword(str),
+    unkeyword(str).
+
+Field terms, where the field contains 'str':
+    bcc(str), body(str), cc(str), from(str), subject(str), text(str), to(str).
+
+Date terms, where date may be a dates.Date.
+    before(date), on(date), sentBefore(date), sentOn(date), sendSince(date),
+    since(date).
+
+Size terms, where size is the entire message size in bytes.
+    larger(size), smaller(size).`);
+
+        // Flags.
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Answered)))("answered", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Deleted)))("deleted", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Draft)))("draft", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Flagged)))("flagged", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.New)))("new", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Old)))("old", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Recent)))("recent", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Seen)))("seen", termDoc);
+        handlers.registerHandler!(() => new
+                                  SearchExpr(FlagTerm(FlagTerm.Flag.Unanswered)))("unanswered", termDoc);
+        handlers.registerHandler!(() => new
+                                  SearchExpr(FlagTerm(FlagTerm.Flag.Undeleted)))("undeleted", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Undraft)))("undraft", termDoc);
+        handlers.registerHandler!(() => new
+                                  SearchExpr(FlagTerm(FlagTerm.Flag.Unflagged)))("unflagged", termDoc);
+        handlers.registerHandler!(() => new SearchExpr(FlagTerm(FlagTerm.Flag.Unseen)))("unseen", termDoc);
+
+        // Keyword.
+        handlers.registerHandler!((string keyw) => new SearchExpr(KeywordTerm(keyw)))("keyword", termDoc);
+        handlers.registerHandler!((string keyw) => new SearchExpr(KeywordTerm(keyw, true)))("unkeyword", termDoc);
+
+        // Fields.
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.Bcc, str)))("bcc", termDoc);
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.Body, str)))("body", termDoc);
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.Cc, str)))("cc", termDoc);
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.From, str)))("from", termDoc);
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.Subject, str)))("subject", termDoc);
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.Text, str)))("text", termDoc);
+        handlers.registerHandler!((string str) => new SearchExpr(FieldTerm(FieldTerm.Field.To, str)))("to", termDoc);
+
+        handlers.registerHandler!((string hdr, string str) => new SearchExpr(HeaderTerm(hdr, str)))("header", termDoc);
+
+        // Dates.
+        import std.datetime : Date;
+        handlers.registerHandler!((Date date) => new SearchExpr(DateTerm(DateTerm.When.Before, date)))("before", termDoc);
+        handlers.registerHandler!((Date date) => new SearchExpr(DateTerm(DateTerm.When.On, date)))("on", termDoc);
+        handlers.registerHandler!((Date date) => new SearchExpr(DateTerm(DateTerm.When.SentBefore, date)))("sentBefore", termDoc);
+        handlers.registerHandler!((Date date) => new SearchExpr(DateTerm(DateTerm.When.SentOn, date)))("sentOn", termDoc);
+        handlers.registerHandler!((Date date) => new SearchExpr(DateTerm(DateTerm.When.SentSince, date)))("sentSince", termDoc);
+        handlers.registerHandler!((Date date) => new SearchExpr(DateTerm(DateTerm.When.Since, date)))("since", termDoc);
+
+        // Sizes.
+        handlers.registerHandler!((int size) => new SearchExpr(SizeTerm(SizeTerm.Relation.Larger, size)))("larger", termDoc);
+        handlers.registerHandler!((int size) => new SearchExpr(SizeTerm(SizeTerm.Relation.Smaller, size)))("smaller", termDoc);
+
+        // UID sequences.
+        // XXX This is tricky.  We'd like some simple syntax to be able to declare them in SIL (I
+        // assume?  Or do we?) but mostly we'd like to use whatever is returned from other APIs
+        // (most likely prior searches).
     }
 }
 
 void writeBinaryString(string file, string data) {
     import std.file;
     write(file, data);
-}
-
-struct X509_ {
-    import deimos.openssl.x509;
-    X509* handle;
 }
 
 struct MimeContainer_ {

--- a/source/kaleidic/sil/plugin/imap/register.d
+++ b/source/kaleidic/sil/plugin/imap/register.d
@@ -1,73 +1,82 @@
 ///
 module kaleidic.sil.plugin.imap.register;
-import imap.set;
-version (SIL) :
 
-    import kaleidic.sil.lang.handlers : Handlers;
-import kaleidic.sil.lang.typing.types : Variable, Function, SILdoc;
+import imap.set;
 import std.meta : AliasSeq;
+
+version (SIL) : import kaleidic.sil.lang.handlers : Handlers;
+
+import kaleidic.sil.lang.typing.types : Variable, Function, SILdoc;
 
 version (SIL_Plugin) {
     import kaleidic.sil.lang.plugin : pluginImpl;
     mixin pluginImpl!registerImap;
 }
 
-
 import imap.defines;
 import imap.socket;
 import imap.session : Session;
 
-import core.stdc.stdio;
-import core.stdc.string;
-import core.stdc.errno;
 import std.socket;
-import core.time : Duration;
-import std.datetime : Date, DateTime, SysTime, TimeZone;
 
-import deimos.openssl.ssl;
-import deimos.openssl.err;
-import deimos.openssl.sha;
 import arsd.email : MimeContainer;
 
 ///
-void registerGrammar(ref Handlers handlers) {
-    import pegged.grammar;
-    import imap.grammar;
-    handlers.registerHandler!parse;
-    handlers.registerHandler!parseTest;
-    // handlers.registerType!ParseTree;
+void registerImap(ref Handlers handlers) {
+    import imap.session;
+    import imap.request;
+    import imap.response;
+    import imap.namespace;
+    import deimos.openssl.ssl;
+    import deimos.openssl.evp;
+    import arsd.email : IncomingEmailMessage, RelayInfo, ToType, EmailMessage, MimePart;
+
+    {
+        handlers.openModule("imap");
+        scope (exit) handlers.closeModule();
+
+        static foreach (T; AliasSeq!(MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
+                                     Status, FlagResult, SearchResult, Session, ProtocolSSL,
+                                     ImapServer, ImapLogin, StatusResult, BodyResponse,
+                                     ListResponse, ListEntry, IncomingEmailMessage, RelayInfo,
+                                     ToType, EmailMessage, MimePart, Options, MimeContainer_,
+                                     MimeAttachment, SearchResultType,
+                                     StoreMode // proxy from imap not arsd
+                                    )) {
+            handlers.registerType!T;
+        }
+
+        handlers.registerType!(Set!Capability)("Capabilities");
+
+        handlers.registerType!(Set!ulong)("UidSet");
+        handlers.registerHandler!(addSet!ulong)("addUidSet");
+        handlers.registerHandler!(removeSet!ulong)("removeUidSet");
+
+        // FIXME - finish and add append
+        static foreach (F; AliasSeq!(noop, login, logout, status, examine, select, close, expunge,
+                                     list, lsub, search, fetchFast, fetchFlags, fetchDate,
+                                     fetchSize, fetchStructure, fetchHeader, fetchText, fetchFields,
+                                     fetchPart, store, copy, create, delete_, rename, subscribe,
+                                     unsubscribe, idle, openConnection, closeConnection,
+                                     fetchRFC822, attachments, writeBinaryString, esearch,
+                                     multiSearch, move, multiMove, moveUIDs,
+                        )) {
+            handlers.registerHandler!F;
+        }
+        handlers.registerType!Socket;
+
+        import jmap : registerHandlersJmap;
+        handlers.registerHandlersJmap();
+    }
+
+    {
+        handlers.openModule("ssl");
+        scope (exit) handlers.closeModule();
+        static foreach (T; AliasSeq!(EVP_MD, SSL_))
+            handlers.registerType!T;
+        handlers.registerType!X509_("X509");
+    }
 }
-
-enum TestImap = `
-* 51235 EXISTS
-* 0 RECENT
-* FLAGS (\Answered \Flagged \Draft \Deleted \Seen $X-ME-Annot-2 $IsMailingList $IsNotification $HasAttachment $HasTD $IsTrusted Recent $NotJunk $client $kaleidic $Forwarded $has_cal Junk $nina $personal $symmetry $sym/feng $contacts $contacts/mf $research/macro $research NonJunk $Junk)
-* OK [PERMANENTFLAGS (\Answered \Flagged \Draft \Deleted \Seen $X-ME-Annot-2 $IsMailingList $IsNotification $HasAttachment $HasTD $IsTrusted Recent $NotJunk $client $kaleidic $Forwarded $has_cal Junk $nina $personal $symmetry $sym/feng $contacts $contacts/mf $research/macro $research NonJunk $Junk \*)] Ok
-* OK [UNSEEN 7] Ok
-* OK [UIDVALIDITY 1484418500] Ok
-* OK [UIDNEXT 70481] Ok
-* OK [HIGHESTMODSEQ 10835882] Ok
-* OK [URLMECH INTERNAL] Ok
-* OK [ANNOTATIONS 65536] Ok
-D1004 OK [READ-WRITE] Completed
-`;
-
-auto parseTest() {
-    import imap.grammar;
-    import std.stdio;
-    auto results = Imap(TestImap);
-    writeln(results);
-    results = results.tee;
-    writeln(results);
-    return results;
-}
-
-
-auto parse(string arg) {
-    import imap.grammar;
-    return Imap(arg).tee;
-}
-
 
 void writeBinaryString(string file, string data) {
     import std.file;
@@ -101,344 +110,3 @@ MimeContainer_ accessMimeContainer(MimeContainer mimeContainer) {
     return MimeContainer_(mimeContainer);
 }
 
-///
-void registerImap(ref Handlers handlers) {
-    import imap.session;
-    import imap.system;
-    import imap.request;
-    import imap.response;
-    import imap.namespace;
-    import core.sys.linux.termios;
-    import std.meta : AliasSeq;
-    import imap.ssl;
-    import deimos.openssl.ssl;
-    import deimos.openssl.err;
-    import deimos.openssl.x509;
-    import deimos.openssl.pem;
-    import deimos.openssl.evp;
-    import std.stdio : File;
-    import arsd.email : IncomingEmailMessage, RelayInfo, ToType, EmailMessage, MimePart;
-
-    {
-        handlers.openModule("dates");
-        handlers.registerHandler!add;
-        handlers.openModule("imap");
-        scope (exit) handlers.closeModule();
-        handlers.registerGrammar();
-
-        static foreach (T; AliasSeq!(MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
-                                     Status, FlagResult, SearchResult, Status, Session, ProtocolSSL, ImapServer, ImapLogin,
-                                     MailboxList, Mailbox, ImapResult, ImapStatus, Result!string,
-                                     Status, FlagResult, SearchResult, Status, StatusResult, BodyResponse, ListResponse, ListEntry,
-                                     IncomingEmailMessage, RelayInfo, ToType, EmailMessage, MimePart, Options,
-                                     MimeContainer_, MimePart,
-                                     MimeAttachment, SearchQuery, UidRange, SearchResultType, StoreMode // proxy from imap not arsd
-                        ))
-            handlers.registerType!T;
-
-        handlers.registerType!(Set!Capability)("Capabilities");
-        handlers.registerType!(Set!ulong)("UidSet");
-        handlers.registerType!SysTime;
-        handlers.registerType!TimeZone;
-        handlers.registerType!Duration;
-
-        handlers.registerHandler!(addSet!ulong)("addUidSet");
-        handlers.registerHandler!(removeSet!ulong)("removeUidSet");
-        // FIXME - finish and add append
-        static foreach (F; AliasSeq!(noop, login, logout, status, examine, select, close, expunge, list, lsub,
-                                     search, fetchFast, fetchFlags, fetchDate, fetchSize, fetchStructure, fetchHeader,
-                                     fetchText, fetchFields, fetchPart, logout, store, copy, create, delete_, rename, subscribe,
-                                     unsubscribe, idle, openConnection, closeConnection, fetchRFC822, attachments, writeBinaryString,
-                                     createQuery, searchQuery, searchQueries, rfcDate, esearch, multiSearch, move, multiMove, moveUIDs,
-                                     extractAddress,
-                        ))
-            handlers.registerHandler!F;
-        handlers.registerType!Socket;
-
-        import jmap : registerHandlersJmap;
-        handlers.registerHandlersJmap();
-    }
-    /+
-    {
-        handlers.openModule("imap.impl");
-        scope(exit) handlers.closeModule();
-        version(linux)
-        {
-            handlers.registerType!termios;
-            handlers.registerHandler!getTerminalAttributes;
-            handlers.registerHandler!setTerminalAttributes;
-            handlers.registerHandler!enableEcho;
-            handlers.registerHandler!disableEcho;
-        }
-
-        static foreach(T; AliasSeq!( AddressInfo, Socket,ImapServer,ImapLogin,File
-        ))
-            handlers.registerType!T;
-        handlers.registerHandler!(add!Capability)("addCapability");
-        handlers.registerHandler!(remove!Capability)("removeCapability");
-        handlers.registerHandler!(addSet!Capability)("addCapabilities");
-        handlers.registerHandler!(removeSet!Capability)("removeCapabilities");
-
-        static foreach(F; AliasSeq!(socketRead,socketWrite,
-                        getTerminalAttributes,setTerminalAttributes,enableEcho,disableEcho,
-                        socketSecureRead,socketSecureWrite,closeSecureConnection,openSecureConnection,
-                        isLoginRequest, sendRequest, sendContinuation,
-        ))
-            handlers.registerHandler!F;
-    }
-    +/
-    // FIXME - add current tag as SIL vairable - static int tag = 0x1000;
-
-    {
-        handlers.openModule("ssl");
-        scope (exit) handlers.closeModule();
-/+
-        static foreach(F; AliasSeq!(getPeerCertificate, getCert, checkCert, readX509,
-                    getDigest,getIssuerName,getSubject,asHex,printCert,getSerial,storeCert,
-                    getFilePath,
-        ))
-        handlers.registerHandler!F; +/
-        static foreach (T; AliasSeq!(EVP_MD, SSL_))
-            handlers.registerType!T;
-        handlers.registerType!X509_("X509");
-    }
-}
-
-struct UidRange {
-    long start = -1;
-    long end = -1;
-
-    string toString() {
-        import std.string : format;
-        import std.conv : to;
-
-        return format!"%s:%s"(
-            (start == -1) ? 0 : start,
-            (end == -1) ? "*" : end.to!string
-        );
-    }
-}
-
-struct SearchQuery {
-    @SILdoc("not flag if applied inverts the whole query")
-    @("NOT")
-    bool not;
-
-    ImapFlag[] flags;
-
-    @("FROM")
-    string fromContains;
-
-    @("CC")
-    string ccContains;
-
-    @("BCC")
-    string bccContains;
-
-    @("TO")
-    string toContains;
-
-    @("SUBJECT")
-    string subjectContains;
-
-    @("BODY")
-    string bodyContains;
-
-    @("TEXT")
-    string textContains;
-
-    @("BEFORE")
-    Date beforeDate;
-
-    @("HEADER")
-    string[string] headerFieldContains;
-
-    @("KEYWORD")
-    string[] hasKeyword;
-
-    @("SMALLER")
-    ulong smallerThanBytes;
-
-    @("LARGER")
-    ulong largerThanBytes;
-
-    @("NEW")
-    bool isNew;
-
-    @("OLD")
-    bool isOld;
-
-    @("ON")
-    Date onDate;
-
-    @("SENTBEFORE")
-    Date sentBefore;
-
-    @("SENTON")
-    Date sentOn;
-
-    @("SENTSINCE")
-    Date sentSince;
-
-    @("SINCE")
-    Date since;
-
-    @("UID")
-    ulong[] uniqueIdentifiers;
-
-    @("UID")
-    UidRange[] uniqueIdentifierRanges;
-
-    string applyNot(string s) {
-        import std.string : join;
-
-        return not ? ("NOT " ~ s) : s;
-    }
-
-    template isSILdoc(alias T) {
-        enum isSILdoc = is(typeof(T) == SILdoc);
-    }
-
-    void toString(scope void delegate(const(char)[]) sink) {
-        import std.range : dropOne;
-        import std.string : toUpper;
-        import std.conv : to;
-        import std.meta : Filter, templateNot;
-        import std.traits : isFunction;
-        foreach (flag; flags) {
-            sink(applyNot(flag.to!string.dropOne.toUpper));
-        }
-        static foreach (M; Filter!(templateNot!isFunction, __traits(allMembers, typeof(this)))) {
-            {
-                enum udas = Filter!(templateNot!isSILdoc, __traits(getAttributes, __traits(getMember, this, M)));
-                static if (udas.length > 0) {
-                    alias T = typeof(__traits(getMember, this, M));
-                    enum name = udas[0].to!string;
-                    auto v = __traits(getMember, this, M);
-                    static if (is(T == string)) {
-                        if (v.length > 0) {
-                            sink(applyNot(name));
-                            sink(" \"");
-                            sink(v);
-                            sink("\" ");
-                        }
-                    } else static if (is(T == Date)) {
-                        if (v != Date.init) {
-                            sink(applyNot(name));
-                            sink(" ");
-                            sink(__traits(getMember, this, M).rfcDate);
-                            sink(" ");
-                        }
-                    } else static if (is(T == bool) && (name != "NOT")) {
-                        if (v) {
-                            sink(applyNot(name));
-                            sink(" ");
-                        }
-                    } else static if (is(T == string[string])) {
-                        foreach (entry; __traits(getMember, this, M).byKeyValue) {
-                            sink(applyNot(name));
-                            sink(" ");
-                            sink(entry.key);
-                            sink(" \"");
-                            sink(entry.value);
-                            sink("\" ");
-                        }
-                    } else static if (is(T == string[])) {
-                        foreach (entry; __traits(getMember, this, M)) {
-                            sink(applyNot(name));
-                            sink(" \"");
-                            sink(entry);
-                            sink("\" ");
-                        }
-                    } else static if (is(T == ulong[])) {
-                        if (v.length > 0) {
-                            sink(applyNot(name));
-                            sink(" ");
-                            auto len = __traits(getMember, this, M).length;
-                            foreach (i, entry; __traits(getMember, this, M)) {
-                                sink(entry.to!string);
-                                if (i != len - 1)
-                                    sink(",");
-                            }
-                            static if (name == "UID") {
-                                if (len > 0 && uniqueIdentifierRanges.length > 0)
-                                    sink(",");
-                                len = uniqueIdentifierRanges.length;
-                                foreach (i, entry; uniqueIdentifierRanges) {
-                                    sink(entry.to!string);
-                                    if (i != len - 1)
-                                        sink(",");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@SILdoc(`Generate query string to serch the selected mailbox according to the supplied criteria.
-This string may be passed to imap.search.
-
-The searchQueries are ORed together.  There is an implicit AND within a searchQuery
-For NOT, set not within the query to be true - this applies to all the conditions within
-the query.
-`)
-string createQuery(SearchQuery[] searchQueries) {
-    import std.range : chain, repeat;
-    import std.algorithm : map;
-    import std.string : join, strip;
-    import std.conv : to;
-
-    if (searchQueries.length == 0)
-        return "ALL";
-
-    return chain("OR".repeat(searchQueries.length - 1),
-            searchQueries.map!(q => q.to!string.strip)).join(" ").strip;
-}
-
-@SILdoc(`Search selected mailbox according to the supplied search criteria.
-There is an implicit AND within a searchQuery. For NOT, set not within the query
-to be true - this applies to all the conditions within the query.
-`)
-auto searchQuery(Session session, string mailbox, SearchQuery searchQuery, string charset = null) {
-    import imap.namespace : Mailbox;
-    import imap.request;
-    select(session, Mailbox(mailbox));
-    return search(session, createQuery([searchQuery]), charset);
-}
-
-@SILdoc(`Search selected mailbox according to the supplied search criteria.
-The searchQueries are ORed together.  There is an implicit AND within a searchQuery
-For NOT, set not within the query to be true - this applies to all the conditions within
-the query.
-`)
-auto searchQueries(Session session, string mailbox, SearchQuery[] searchQueries, string charset = null) {
-    import imap.namespace : Mailbox;
-    import imap.request;
-    select(session, Mailbox(mailbox));
-    return search(session, createQuery(searchQueries), charset);
-}
-
-@SILdoc("Convert a SIL date to an RFC-2822 / IMAP Date string")
-string rfcDate(Date date) {
-    import std.format : format;
-    import std.conv : to;
-    import std.string : capitalize;
-    return format!"%02d-%s-%04d"(date.day, date.month.to!string.capitalize, date.year);
-}
-
-@SILdoc("Extract email address from sender/recipient eg Laeeth <laeeth@nospam-laeeth.com>")
-string extractAddress(string arg) {
-    import std.string : indexOf;
-    auto i = arg.indexOf("<");
-    auto j = arg.indexOf(">");
-    if ((i == -1) || (j == -1) || (j <= i))
-        return "";
-    return arg[i + 1 .. j];
-}
-
-Variable add(Variable date, Duration dur) {
-    return Variable(date.get!DateTime + dur);
-}


### PR DESCRIPTION
OK, this has been tricky and has taken me a couple of weeks to work through.  It still has a couple of bits missing but I think it's at a good place.

The biggest difference is search queries are now arbitrarily composable.  There are basic terms like `seen` or `subject("foobar")` and they can be joined with boolean operations `and`, `or` and `not`.

In D it's pretty verbose though.  You can see in the `unittest`s in `searchquery.d`.  I'm not sure if this is a problem or if it can be made less verbose; I'm still not 100% up to speed with idiomatic D.

In SIL it's less verbose and I think quite OK.  By using `import * from imap.query` each of the terms and operators are brought into immediate scope and creating a search query expression is fairly straight forward and much simpler than trying to document the `SEARCH` syntax from RFC3501.