### PR TITLE
Search known paths for the CA certificate file on Linux.

### DIFF
--- a/source/imap/session.d
+++ b/source/imap/session.d
@@ -111,8 +111,6 @@ struct Options {
     string logFile;
     string configFile;
     string oneline;
-    string trustStore = "/etc/ssl/certs";
-    string trustFile = "/etc/ssl/certs/cert.pem";
     Duration timeout = 20.seconds;
 }
 


### PR DESCRIPTION
Instead of assuming the path (under /etc/ssl) we check a list of places
it might be, since this differs between distros.  Taken from a Go
example.