### PR TITLE
Register missing socket and capability enums

### DIFF
--- a/source/kaleidic/sil/plugin/imap/register.d
+++ b/source/kaleidic/sil/plugin/imap/register.d
@@ -58,6 +58,11 @@ void registerImap(ref Handlers handlers) {
         }
 
         handlers.registerType!Socket;
+        handlers.registerType!SocketFlags;
+        handlers.registerType!SocketOption;
+        handlers.registerType!SocketOptionLevel;
+        handlers.registerType!SocketShutdown;
+        handlers.registerType!Capability;
         handlers.registerType!(Set!Capability)("Capabilities");
         handlers.registerType!(Set!ulong)("UidSet");
 


### PR DESCRIPTION
SIL has better enum handling now and stringy enums are deprecated so this allows you to use the enums properly.