### PR TITLE
Update dub.sdl

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,7 +1,7 @@
 name "symmetry-imap"
 description "IMAP client library"
 license "MIT"
-dependency "arsd-official:email" version="~>8.5"
+dependency "arsd-official:email" version=">=8.5"
 dependency "openssl" version="~>1.1.6"
 dependency "requests" version="~>2"
 dependency "asdf" version="~>0.6"


### PR DESCRIPTION
The arsd lib basically never actually breaks so the >= version gives more flexibility for when this lib is combined with others.