### PR TITLE
 More flexible arsd version specifier

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,7 +1,7 @@
 name "symmetry-imap"
 description "IMAP client library"
 license "MIT"
-dependency "arsd-official:email" version="~>8.5"
+dependency "arsd-official:email" version=">=8.5.0"
 dependency "openssl" version="~>1.1.6"
 dependency "requests" version="~>2"
 dependency "asdf" version="~>0.6"


### PR DESCRIPTION
It rarely actually breaks so no point pinning the major version.