### PR TITLE
Add @serdeIgnoreUnexpectedKeys

### DIFF
--- a/source/jmap/types.d
+++ b/source/jmap/types.d
@@ -94,6 +94,7 @@ struct Account {
     StringMap!string primaryAccounts;
 }
 
+@serdeIgnoreUnexpectedKeys
 struct Session {
     @serdeOptional
     SessionCoreCapabilities coreCapabilities;


### PR DESCRIPTION
The change is required to preserve the current deserialization behavior with the upcoming mir-ion 1.1.