### PR TITLE
add authors line

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,5 +1,6 @@
 name "symmetry-imap"
 description "IMAP client library"
+authors "Laeeth Isharc" "Sebastiaan Koppe" "John Colvin" "Ilya Yaroshenko" "Martin Kinke" "Max Haughton" "Francesco Mecca" "Toby Hutton"
 license "MIT"
 dependency "arsd-official:email" version=">=8.5.0"
 dependency "openssl" version=">=3.1.0"


### PR DESCRIPTION
Add authorship line.  I think I wrote this mostly in my spare time and it's ambiguous whether it would strictly be Symmetry's IP.  Symmetry is welcome to it though.  But I think as a matter of good practice the authors should be listed, even though you can see the commit log for yourself.